### PR TITLE
Ensure host device ops finish before reseting fences

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -32,7 +32,6 @@ jobs:
       run: |
         bazel test \
           --graphics_drivers=gles_angle_vulkan_swiftshader \
-          --test_arg="--gtest_filter=-*MultiThreadedResetCommandBuffer*" \
           --test_output=streamed \
           --verbose_failures \
           common/end2end:gfxstream_end2end_tests

--- a/common/end2end/GfxstreamEnd2EndVkTests.cpp
+++ b/common/end2end/GfxstreamEnd2EndVkTests.cpp
@@ -2123,6 +2123,7 @@ TEST_P(GfxstreamEnd2EndVkTest, MultiThreadedResetCommandBuffer) {
 
             const vkhpp::CommandPoolCreateInfo commandPoolCreateInfo = {
                 .queueFamilyIndex = queueFamilyIndex,
+                .flags = vkhpp::CommandPoolCreateFlagBits::eResetCommandBuffer,
             };
             auto commandPool = device->createCommandPoolUnique(commandPoolCreateInfo).value;
 


### PR DESCRIPTION
... as otherwise the `VkFence` saved in `DeviceOpTracker` may become invalid before the `vkGetFenceStatus()` occurs.

Test:

```
bazel test common/end2end:gfxstream_end2end_tests \
  --graphics_drivers=gles_angle_vulkan_swiftshader \
  --test_arg="--gtest_filter=*MultiThreadedResetCommandBuffer*:-*MultiThreadedResetCommandBuffer*VulkanSnapshots*" \
  --test_arg="--gtest_repeat=100" \
  --test_output=streamed
```