### PR TITLE
Remove inc_gfxstream_include from meson entirely

### DIFF
--- a/host/decoder_common/meson.build
+++ b/host/decoder_common/meson.build
@@ -23,7 +23,6 @@ lib_host_decoder_common = static_library(
   include_directories: [
     inc_common_base,
     inc_common_opengl,
-    inc_gfxstream_include,
     inc_host_decoder_common,
     inc_host_include,
     inc_host_library,

--- a/host/gl/OpenGLESDispatch/meson.build
+++ b/host/gl/OpenGLESDispatch/meson.build
@@ -20,7 +20,6 @@ lib_gl_openglesdispatch = static_library(
   include_directories: [
     inc_common_base,
     inc_common_opengl,
-    inc_gfxstream_include,
     inc_gl_openglesdispatch,
     inc_include,
   ],

--- a/host/gl/glestranslator/EGL/meson.build
+++ b/host/gl/glestranslator/EGL/meson.build
@@ -58,7 +58,6 @@ lib_egl_translator = static_library(
     inc_common_opengl,
     inc_common_utils,
     inc_etc,
-    inc_gfxstream_include,
     inc_gfxstream_server,
     inc_gl_common,
     inc_gl_openglesdispatch,

--- a/host/gl/glestranslator/GLcommon/meson.build
+++ b/host/gl/glestranslator/GLcommon/meson.build
@@ -31,7 +31,6 @@ lib_gl_common = static_library(
     inc_common_base,
     inc_common_opengl,
     inc_etc,
-    inc_gfxstream_include,
     inc_gfxstream_server,
     inc_gl_common,
     inc_gl_openglesdispatch,

--- a/host/gl/glsnapshot/meson.build
+++ b/host/gl/glsnapshot/meson.build
@@ -11,7 +11,6 @@ lib_gl_snapshot = static_library(
   cpp_args: gfxstream_host_args,
   include_directories: [
     inc_gl_openglesdispatch,
-    inc_gfxstream_include,
     inc_include,
     inc_opengl_headers
   ],

--- a/host/gl/meson.build
+++ b/host/gl/meson.build
@@ -50,7 +50,6 @@ lib_gl_server = static_library(
     inc_common_logging,
     inc_common_opengl,
     inc_common_utils,
-    inc_gfxstream_include,
     inc_gfxstream_server,
     inc_gl_common,
     inc_gl_openglesdispatch,

--- a/host/meson.build
+++ b/host/meson.build
@@ -92,13 +92,8 @@ inc_common_opengl = include_directories('../third_party/opengl/include')
 inc_drm_headers = include_directories('../third_party/drm/include')
 
 inc_root = include_directories('../')
-inc_gfxstream_include = []
 # Included by all host component builds. Leave empty for future build updates.
 inc_include = include_directories()
-
-if host_machine.system() == 'qnx'
-  inc_gfxstream_include = [inc_qnx_headers, inc_gfxstream_include]
-endif
 
 if use_vulkan
   inc_vulkan_headers = include_directories('../third_party/vulkan/include')
@@ -141,7 +136,6 @@ inc_gfxstream_backend = [
   inc_common_opengl,
   inc_common_utils,
   inc_drm_headers,
-  inc_gfxstream_include,
   inc_glm,
   inc_host_address_space,
   inc_host_backend,

--- a/host/vulkan/emulated_textures/meson.build
+++ b/host/vulkan/emulated_textures/meson.build
@@ -18,7 +18,6 @@ lib_emulated_textures = static_library(
   include_directories: [
     inc_cereal_common,
     inc_common_base,
-    inc_gfxstream_include,
     inc_host_compressed_textures,
     inc_host_decoder_common,
     inc_host_health,

--- a/host/vulkan/meson.build
+++ b/host/vulkan/meson.build
@@ -67,7 +67,6 @@ lib_vulkan_server = static_library(
     inc_cereal,
     inc_common_base,
     inc_common_utils,
-    inc_gfxstream_include,
     inc_gl_openglesdispatch,
     inc_gl_server,
     inc_glm,


### PR DESCRIPTION
It's not needed for QNX anymore, they are already included with the `qnx_<something_deps ...` in the meson build.