### PR TITLE
Add a thread safety helper to WorkerThread.h

### DIFF
--- a/common/base/include/gfxstream/threads/WorkerThread.h
+++ b/common/base/include/gfxstream/threads/WorkerThread.h
@@ -143,7 +143,11 @@ class WorkerThread {
         for (;;) {
             {
                 std::unique_lock<std::mutex> lock(mMutex);
-                mCv.wait(lock, [this]{ return !mQueue.empty(); });
+                ScopedLockAssertion lockAssertion(mMutex);
+                mCv.wait(lock, [this]{
+                    ScopedLockAssertion lockAssertion(mMutex);
+                    return !mQueue.empty();
+                });
                 todo.swap(mQueue);
             }
 


### PR DESCRIPTION
... to help thread safety analysis realize that the lock is acquired inside of the condition variable callback.