### PR TITLE
Ignore -Wself-move errors in ManagedDescriptor_unittest.cpp case

### DIFF
--- a/common/base/ManagedDescriptor_unittest.cpp
+++ b/common/base/ManagedDescriptor_unittest.cpp
@@ -101,9 +101,18 @@ TEST(ManagedDescriptorTest, ShouldCloseOnceIfMoved) {
         EXPECT_CALL(platformTrait, closeDescriptor(rawDescriptor)).Times(1);
         {
             ManagedDescriptorForTesting descriptor(rawDescriptor, platformTrait);
+// Self moves are discouraged but want to test that it still works:
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wself-move"
+#endif
             descriptor = std::move(descriptor);
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
         }
     }
+
     {
         PlatformTraitTest::DescriptorType anotherRawDescriptor = 2871;
         EXPECT_CALL(platformTrait, closeDescriptor(rawDescriptor)).Times(1);


### PR DESCRIPTION
... which is explicitly testing that it still works.