### PR TITLE
Update kokoro continuous to run the same stuff as presubmit

### DIFF
--- a/.kokoro/continuous.cfg
+++ b/.kokoro/continuous.cfg
@@ -1,1 +1,1 @@
-build_file: "gfxstream/.kokoro/run_kokoro_tests.sh"
+presubmit.cfg


### PR DESCRIPTION
It doesn't show up very well in the github change UI ... but this just converted continuous.cfg to be a soft link to presubmit.cfg