### PR TITLE
Fix Linux host-build with some distributions

### DIFF
--- a/host/meson.build
+++ b/host/meson.build
@@ -163,7 +163,7 @@ if host_machine.system() == 'linux'
   deps_gfxstream_backend += [
     thread_dep,
   ]
-  link_args_gfxstream_backend = '-Wl,-lpthread,-lrt'
+  link_args_gfxstream_backend = '-Wl,-lpthread,-lrt,-ldl'
 endif
 
 if host_machine.system() == 'qnx'


### PR DESCRIPTION
Depending on GCC environment, `libdl` may be required to be specified explicitly (used by SharedLibrary.cpp implementation).