### PR TITLE
Support guest-side SCREEN_BUFFER_BIT_QNX extMem handleTypes in host-side translations

### DIFF
--- a/host/vulkan/VkCommonOperations.cpp
+++ b/host/vulkan/VkCommonOperations.cpp
@@ -3990,6 +3990,12 @@ VkExternalMemoryHandleTypeFlags VkEmulation::transformExternalMemoryHandleTypeFl
         res |= getDefaultExternalMemoryHandleType();
     }
 
+    // Replace guest QNX Screen buffer bits with host's default external memory bits
+    if (bits & VK_EXTERNAL_MEMORY_HANDLE_TYPE_SCREEN_BUFFER_BIT_QNX) {
+        res &= ~VK_EXTERNAL_MEMORY_HANDLE_TYPE_SCREEN_BUFFER_BIT_QNX;
+        res |= getDefaultExternalMemoryHandleType();
+    }
+
     // If the host does not support dmabuf, replace guest Linux DMA_BUF bits with
     // the host's default external memory bits,
     if (!mDeviceInfo.supportsDmaBuf && (bits & VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT)) {

--- a/host/vulkan/VkDecoderGlobalState.cpp
+++ b/host/vulkan/VkDecoderGlobalState.cpp
@@ -8762,7 +8762,8 @@ class VkDecoderGlobalState::Impl {
 
 #define GUEST_EXTERNAL_MEMORY_HANDLE_TYPES                                \
     (VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID | \
-     VK_EXTERNAL_MEMORY_HANDLE_TYPE_ZIRCON_VMO_BIT_FUCHSIA)
+     VK_EXTERNAL_MEMORY_HANDLE_TYPE_ZIRCON_VMO_BIT_FUCHSIA | \
+     VK_EXTERNAL_MEMORY_HANDLE_TYPE_SCREEN_BUFFER_BIT_QNX)
 
     // Transforms
     // If adding a new transform here, please check if it needs to be used in VkDecoderTestDispatch


### PR DESCRIPTION
Self-explanatory. A little bit odd that we have to do this to support new guest-types ... in the future, this should probably be communicated to the guest (at init?) so that the guest can do this.

Testing:
Starting to get a QNX port running. Just got guest-side VK_QNX_external_memory_screen_buffer running with a (currently internal) QNX port of the guest-side stack.