### PR TITLE
Fix data race in TestClock

### DIFF
--- a/host/health/Android.bp
+++ b/host/health/Android.bp
@@ -24,6 +24,7 @@ cc_library_static {
     ],
     srcs: [
         "HealthMonitor.cpp",
+        "TestClock.cpp",
     ],
     static_libs: [
         "libgfxstream_common_base",

--- a/host/health/BUILD.bazel
+++ b/host/health/BUILD.bazel
@@ -8,7 +8,10 @@ package(
 
 cc_library(
     name = "gfxstream_host_health",
-    srcs = ["HealthMonitor.cpp"],
+    srcs = [
+        "HealthMonitor.cpp",
+        "TestClock.cpp",
+    ],
     hdrs = glob(["include/**/*.h"]),
     copts = GFXSTREAM_HOST_COPTS,
     defines = GFXSTREAM_HOST_DEFINES,

--- a/host/health/CMakeLists.txt
+++ b/host/health/CMakeLists.txt
@@ -14,7 +14,8 @@
 
 add_library(
     gfxstream_host_health
-    HealthMonitor.cpp)
+    HealthMonitor.cpp
+    TestClock.cpp)
 
 target_include_directories(
     gfxstream_host_health

--- a/host/health/TestClock.cpp
+++ b/host/health/TestClock.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "gfxstream/TestClock.h"
+
+#include <mutex>
+
+namespace gfxstream {
+namespace base {
+namespace {
+
+static std::mutex gInternalTimeMutex;
+static double gInternalTime = 0.0;
+
+}  // namespace
+
+/*static*/ TestClock::time_point TestClock::now() {
+    std::lock_guard<std::mutex> lock(gInternalTimeMutex);
+    return time_point(duration(gInternalTime));
+}
+
+/*static*/ void TestClock::advance(double secondsPassed) {
+    std::lock_guard<std::mutex> lock(gInternalTimeMutex);
+    gInternalTime += secondsPassed;
+}
+
+/*static*/ void TestClock::reset() {
+    std::lock_guard<std::mutex> lock(gInternalTimeMutex);
+    gInternalTime = 0.0;
+}
+
+}  // namespace base
+}  // namespace gfxstream

--- a/host/health/include/gfxstream/TestClock.h
+++ b/host/health/include/gfxstream/TestClock.h
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 #pragma once
 
 #include <chrono>
@@ -28,17 +29,11 @@ class TestClock {
     using time_point = std::chrono::time_point<TestClock>;
     const bool is_steady = false;
 
-    static time_point now() { return time_point(duration(getInternalTime())); }
+    static time_point now();
 
-    static void advance(double secondsPassed) { getInternalTime() += secondsPassed; }
+    static void advance(double secondsPassed);
 
-    static void reset() { getInternalTime() = 0.0; }
-
-   private:
-    static double& getInternalTime() {
-        static double internalTime = 0.0;
-        return internalTime;
-    }
+    static void reset();
 };
 
 }  // namespace base

--- a/host/health/meson.build
+++ b/host/health/meson.build
@@ -5,6 +5,7 @@ inc_host_health = include_directories('include')
 
 files_lib_host_health = files(
   'HealthMonitor.cpp',
+  'TestClock.cpp',
 )
 
 lib_host_health = static_library(


### PR DESCRIPTION
... by guarding the time var.

Bug: b/440785839
Bug: b/441269151
Test: bazel test host/health:gfxstream_host_health_tests