### PR TITLE
Add back licenses(["notice"])

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -31,3 +31,5 @@ license(
     package_url = "https://android.googlesource.com/platform/hardware/google/gfxstream/",
     visibility = ["//visibility:public"],
 )
+
+licenses(["notice"])


### PR DESCRIPTION
Dropped in ag/38785916 but the internal import complains if it is missing.

Bug: b/478889523
Test: manually running the internal import
Change-Id: Ibcef411e6d39c738fe1aca7988baa49274f3776e