### PR TITLE
Fix use-after-free in EglDisplay destructor when terminate() not called

### DIFF
--- a/host/gl/glestranslator/egl/egl_display.cpp
+++ b/host/gl/glestranslator/egl/egl_display.cpp
@@ -38,6 +38,10 @@ EglDisplay::EglDisplay(EGLNativeDisplayType dpy,
 EglDisplay::~EglDisplay() {
     gfxstream::base::AutoLock mutex(m_lock);
 
+    // In case terminate() was not called:
+    m_contexts.clear();
+    m_surfaces.clear();
+
     m_configs.clear();
 
     delete m_manager[GLES_1_1];


### PR DESCRIPTION
m_contexts and m_surfaces hold objects whose destructors reference m_manager[]. The destructor body calls `delete m_manager[]` explicitly, but member variables are destroyed by C++ after the destructor body completes. If terminate() was never called, m_contexts and m_surfaces are still populated at that point, so their elements are destroyed after m_manager[] is already freed.

terminate() avoids this by clearing both maps while m_manager[] is still alive, but that only helps if it is actually called. Replicate the same clearing at the top of the destructor body so the fix applies regardless.