### PR TITLE
Fix s_glUnmapBufferAEMU and s_glUnmapBufferDMA to return GL_FALSE on …

### DIFF
--- a/host/gl/gles2_dec/gles_v2_decoder.cpp
+++ b/host/gl/gles2_dec/gles_v2_decoder.cpp
@@ -397,6 +397,7 @@ void GLESv2Decoder::s_glUnmapBufferAEMU(void* self, GLenum target, GLintptr offs
         void* gpu_ptr = ctx->glMapBufferRange(target, offset, length, access);
         if (!gpu_ptr) {
             fprintf(stderr, "%s: could not get host gpu pointer!\n", __FUNCTION__);
+            *out_res = GL_FALSE;
             return;
         }
         memcpy(gpu_ptr, guest_buffer, length);
@@ -441,6 +442,7 @@ void GLESv2Decoder::s_glUnmapBufferDMA(void* self, GLenum target, GLintptr offse
         void* gpu_ptr = ctx->glMapBufferRange(target, offset, length, access);
         if (!gpu_ptr) {
             fprintf(stderr, "%s: could not get host gpu pointer!\n", __FUNCTION__);
+            *out_res = GL_FALSE;
             return;
         }
         memcpy(gpu_ptr, guest_buffer, length);


### PR DESCRIPTION
…map failure

s_glUnmapBufferAEMU and s_glUnmapBufferDMA both initialize *out_res = GL_TRUE at entry, then call glMapBufferRange to obtain a GPU-side pointer before copying guest data into the buffer. When glMapBufferRange returns null (e.g. because no buffer is bound to the target yet), the functions logged the error and returned early without updating *out_res.

This caused the guest's glUnmapBuffer call to observe GL_TRUE (success) even though the host never wrote the guest's data into the GPU buffer. Per the OpenGL ES specs, glUnmapBuffer must return GL_FALSE when it cannot guarantee that the buffer's data store now contains the mapped content. Returning GL_TRUE in this case gives the guest a false signal of success, potentially causing it to use a buffer whose contents are stale or undefined.