### PR TITLE
fix(gfxstream): check linear buffer size before copy-path transfers

### DIFF
--- a/host/virtio_gpu_resource.cpp
+++ b/host/virtio_gpu_resource.cpp
@@ -532,6 +532,12 @@ int VirtioGpuResource::ReadFromPipeToLinear(uint64_t offset, stream_renderer_box
         return -EINVAL;
     }
 
+    size_t requiredSize = box->x + box->w;
+    if (mLinear.size() < requiredSize) {
+        GFXSTREAM_ERROR("mLinear is too small! size: %zu, required: %zu", mLinear.size(), requiredSize);
+        return -EINVAL;
+    }
+
     return mHostPipe->TransferFromHost(mLinear.data() + box->x, box->w);
 }
 
@@ -563,6 +569,12 @@ int VirtioGpuResource::ReadFromBufferToLinear(uint64_t offset, stream_renderer_b
 
     if (!mCreateArgs) {
         GFXSTREAM_ERROR("Failed to transfer: resource %d missing args.", mId);
+        return -EINVAL;
+    }
+
+    size_t requiredSize = mCreateArgs->width * mCreateArgs->height;
+    if (mLinear.size() < requiredSize) {
+        GFXSTREAM_ERROR("mLinear is too small! size: %zu, required: %zu", mLinear.size(), requiredSize);
         return -EINVAL;
     }
 
@@ -604,6 +616,13 @@ int VirtioGpuResource::ReadFromColorBufferToLinear(uint64_t offset, stream_rende
         return -EINVAL;
     }
     auto format = *formatOpt;
+
+    size_t requiredSize = GetTransferSize(mCreateArgs->format, mCreateArgs->width, mCreateArgs->height,
+                                          0, 0, mCreateArgs->width, mCreateArgs->height);
+    if (mLinear.size() < requiredSize) {
+        GFXSTREAM_ERROR("mLinear is too small! size: %zu, required: %zu", mLinear.size(), requiredSize);
+        return -EINVAL;
+    }
 
     // We always xfer the whole thing again from GL
     // since it's fiddly to calc / copy-out subregions


### PR DESCRIPTION
Due to timing issues (e.g., during rapid surface recreation or rotation), the system may fail to import zero-copy resources and fall back to the copy-path. If this occurs, `mLinear` might be empty, leading to a host-side null pointer dereference crash.

This CL adds robust defensive checks to `ReadFromPipeToLinear`, `ReadFromBufferToLinear`, and `ReadFromColorBufferToLinear` to verify that `mLinear` is allocated and large enough before copying, safely returning `-EINVAL` otherwise.

Bug: 511078953
Test: Verified host stability under forced fallback and rapid orientation transitions.
Change-Id: I300d383ffb50ba7378518378cd5bde47d37541d9