### PR TITLE
vulkan: Build emulated physical device memory tests in CMake Vulkan unittests

### DIFF
--- a/host/CMakeLists.txt
+++ b/host/CMakeLists.txt
@@ -328,6 +328,7 @@ endfunction()
         vulkan/display_vk_unittest.cpp
         vulkan/swap_chain_state_vk_unittest.cpp
         vulkan/vk_decoder_global_state_unittest.cpp
+        vulkan/vk_emulated_physical_device_memory_tests.cpp
         vulkan/vk_format_utils_unittest.cpp
         vulkan/vk_qsri_timeline_unittest.cpp
         vulkan/vk_utils_tests.cpp


### PR DESCRIPTION
The vk_emulated_physical_device_memory_tests.cpp suite was only wired into the Bazel build, so the CMake build used by android/rebuild.sh never compiled or ran it. Add it to the Vulkan_unittests target so these tests run as part of the standard emulator unit test suite.

Test: verify it with emu-main-dev branch.