### PR TITLE
gfxstream/egl: grant best-available GLES context instead of failing OpenGL ES 3.2

### DIFF
--- a/guest/egl/egl.cpp
+++ b/guest/egl/egl.cpp
@@ -1781,34 +1781,34 @@ EGLContext eglCreateContext(EGLDisplay dpy, EGLConfig config, EGLContext share_c
     case 1:
     case 2:
         break;
-    case 3:
+    case 3: {
         if (rcEnc->getGLESMaxVersion() < GLES_MAX_VERSION_3_0) {
             GFXSTREAM_ERROR("EGL_BAD_CONFIG: no ES 3 support");
             setErrorReturn(EGL_BAD_CONFIG, EGL_NO_CONTEXT);
         }
-        switch (minorVersion) {
-            case 0:
-                break;
-            case 1:
-                if (rcEnc->getGLESMaxVersion() < GLES_MAX_VERSION_3_1) {
-                    GFXSTREAM_ERROR("EGL_BAD_CONFIG: no ES 3.1 support");
-                    setErrorReturn(EGL_BAD_CONFIG, EGL_NO_CONTEXT);
-                }
-                break;
-            case 2:
-                if (rcEnc->getGLESMaxVersion() < GLES_MAX_VERSION_3_2) {
-                    GFXSTREAM_ERROR("EGL_BAD_CONFIG: no ES 3.2 support");
-                    setErrorReturn(EGL_BAD_CONFIG, EGL_NO_CONTEXT);
-                }
-                break;
-            default:
-                GFXSTREAM_ERROR("EGL_BAD_CONFIG: Unknown ES version %d.%d",
-                                majorVersion, minorVersion);
-                setErrorReturn(EGL_BAD_CONFIG, EGL_NO_CONTEXT);
+        if (minorVersion < 0 || minorVersion > 2) {
+            GFXSTREAM_ERROR("EGL_BAD_CONFIG: Unknown ES version %d.%d",
+                            majorVersion, minorVersion);
+            setErrorReturn(EGL_BAD_CONFIG, EGL_NO_CONTEXT);
+        }
+        // The host GLES translator tops out at ES 3.1 (ANDROID_EMU_gles_max_
+        // version_3_1) even on a 3.2-capable host GL. Clamp the requested ES 3.x
+        // minor version down to the host maximum and grant the best available
+        // context instead of returning EGL_BAD_CONFIG, so apps that ask for a
+        // higher version keep running rather than aborting on context creation.
+        int hostMaxMinor =
+            (rcEnc->getGLESMaxVersion() >= GLES_MAX_VERSION_3_2) ? 2 :
+            (rcEnc->getGLESMaxVersion() >= GLES_MAX_VERSION_3_1) ? 1 : 0;
+        if (minorVersion > hostMaxMinor) {
+            GFXSTREAM_WARNING("Requested GLES 3.%d but host supports at most "
+                              "3.%d; granting a 3.%d context",
+                              minorVersion, hostMaxMinor, hostMaxMinor);
+            minorVersion = hostMaxMinor;
         }
         break;
+    }
     default:
-        GFXSTREAM_ERROR("%s:%d EGL_BAD_CONFIG: invalid major GLES version: %d", majorVersion);
+        GFXSTREAM_ERROR("EGL_BAD_CONFIG: invalid major GLES version: %d", majorVersion);
         setErrorReturn(EGL_BAD_CONFIG, EGL_NO_CONTEXT);
     }
 

--- a/tests/end2end/gfxstream_end2end_gl_tests.cpp
+++ b/tests/end2end/gfxstream_end2end_gl_tests.cpp
@@ -327,6 +327,74 @@ TEST_P(GfxstreamEnd2EndGlTest, ContextStrings) {
     ASSERT_THAT(mGl->eglDestroySurface(display, surface), IsTrue());
 }
 
+// Requesting a GLES 3.x context whose minor version exceeds what the host GLES
+// translator supports (it tops out at ES 3.1) must not fail: eglCreateContext
+// clamps the request down to the host maximum and returns a usable context
+// instead of EGL_NO_CONTEXT. Without the clamp, apps that ask for the highest
+// available GLES version abort on context creation.
+TEST_P(GfxstreamEnd2EndGlTest, RequestEs32ContextClampsInsteadOfFailing) {
+    EGLDisplay display = mGl->eglGetDisplay(EGL_DEFAULT_DISPLAY);
+    ASSERT_THAT(display, Not(Eq(EGL_NO_DISPLAY)));
+
+    int versionMajor = 0;
+    int versionMinor = 0;
+    ASSERT_THAT(mGl->eglInitialize(display, &versionMajor, &versionMinor), IsTrue());
+
+    ASSERT_THAT(mGl->eglBindAPI(EGL_OPENGL_ES_API), IsTrue());
+
+    // clang-format off
+    static const EGLint configAttributes[] = {
+        EGL_SURFACE_TYPE,    EGL_PBUFFER_BIT,
+        EGL_RENDERABLE_TYPE, EGL_OPENGL_ES3_BIT,
+        EGL_NONE,
+    };
+    // clang-format on
+
+    int numConfigs = 0;
+    ASSERT_THAT(mGl->eglChooseConfig(display, configAttributes, nullptr, 1, &numConfigs), IsTrue());
+    ASSERT_THAT(numConfigs, Gt(0));
+
+    EGLConfig config = nullptr;
+    ASSERT_THAT(mGl->eglChooseConfig(display, configAttributes, &config, 1, &numConfigs), IsTrue());
+    ASSERT_THAT(config, Not(Eq(nullptr)));
+
+    // Explicitly request an ES 3.2 context. The host translator caps at ES 3.1,
+    // so before the clamp this returned EGL_NO_CONTEXT; now it must grant the
+    // best available 3.x context.
+    // clang-format off
+    static const EGLint es32ContextAttribs[] = {
+        EGL_CONTEXT_MAJOR_VERSION_KHR, 3,
+        EGL_CONTEXT_MINOR_VERSION_KHR, 2,
+        EGL_NONE,
+    };
+    // clang-format on
+
+    EGLContext context = mGl->eglCreateContext(display, config, EGL_NO_CONTEXT, es32ContextAttribs);
+    ASSERT_THAT(context, Not(Eq(EGL_NO_CONTEXT)));
+
+    constexpr const int width = 32;
+    constexpr const int height = 32;
+
+    // clang-format off
+    static const EGLint surfaceAttributes[] = {
+        EGL_WIDTH,  width,
+        EGL_HEIGHT, height,
+        EGL_NONE,
+    };
+    // clang-format on
+
+    EGLSurface surface = mGl->eglCreatePbufferSurface(display, config, surfaceAttributes);
+    ASSERT_THAT(surface, Not(Eq(EGL_NO_SURFACE)));
+
+    ASSERT_THAT(mGl->eglMakeCurrent(display, surface, surface, context), IsTrue());
+    const auto versionString = (const char*)mGl->glGetString(GL_VERSION);
+    EXPECT_THAT(versionString, HasSubstr("ES 3"));
+
+    ASSERT_THAT(mGl->eglMakeCurrent(display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT), IsTrue());
+    ASSERT_THAT(mGl->eglDestroyContext(display, context), IsTrue());
+    ASSERT_THAT(mGl->eglDestroySurface(display, surface), IsTrue());
+}
+
 TEST_P(GfxstreamEnd2EndGlTest, FramebufferFetchShader) {
     const std::string extensionsString = (const char*)mGl->glGetString(GL_EXTENSIONS);
     ASSERT_THAT(extensionsString, Not(IsEmpty()));


### PR DESCRIPTION
The emulator's host GLES translator caps at ES 3.1 (ANDROID_EMU_gles_max_version_3_1) even on a 3.2-capable host GL. The guest eglCreateContext returned EGL_BAD_CONFIG when an app requested an ES 3.2 (or 3.1, when the host caps below 3.1) context, with no fallback, so apps that request the highest available GLES version abort instead of running.

Clamp the requested ES 3.x minor version down to the host maximum (3.2 -> 3.1 -> 3.0) and grant the best available context rather than returning EGL_BAD_CONFIG, matching the graceful-degradation behaviour expected on the emulator. A warning is logged when the request is clamped. No GLES regression: gles3jni + hello-gl2 still pass.

Also fix the invalid-major-version GFXSTREAM_ERROR format string in the same switch, which had three conversion specifiers ("%s:%d ... %d") but only one argument (undefined behaviour when reached).

Add an end2end regression test (RequestEs32ContextClampsInsteadOfFailing) that asserts an explicit ES 3.2 context request yields a usable "ES 3" context rather than EGL_NO_CONTEXT.

Change-Id: I195920a3276f3e5bd223b74f3b6420f0614fe819