### PR TITLE
Fix ColorBuffer allocation by using AHB import instead of export

### DIFF
--- a/host/Android.bp
+++ b/host/Android.bp
@@ -166,6 +166,9 @@ cc_defaults {
         },
         android: {
             srcs: ["native_sub_window_android.cpp"],
+            shared_libs: [
+                "libnativewindow",
+            ],
         },
     },
 }

--- a/host/vulkan/vk_common_operations.cpp
+++ b/host/vulkan/vk_common_operations.cpp
@@ -58,6 +58,10 @@
 #include "platform_helper_qnx.h"
 #endif
 
+#ifdef __ANDROID__
+#include <android/hardware_buffer.h>
+#endif
+
 namespace gfxstream {
 namespace host {
 namespace vk {
@@ -1106,6 +1110,7 @@ std::unique_ptr<VkEmulation> VkEmulation::create(VulkanDispatch* gvk,
             if (deviceInfos[i].externalMemoryMode == ExternalMemory::Mode::QnxScreenBuffer) {
                 deviceInfos[i].supportsExternalMemoryExport = false;
             }
+
         }
 
         if (emulation->mInstanceSupportsGetPhysicalDeviceProperties2) {
@@ -2055,6 +2060,63 @@ MTLResource_id VkEmulation::getMtlResourceFromVkDeviceMemory(VulkanDispatch* vk,
 }
 #endif
 
+#ifdef __ANDROID__
+// Allocate an AHardwareBuffer matching the given image's format, extent and usage.
+// Returns nullptr on failure (caller falls back to the non-AHB allocation path).
+static AHardwareBuffer* allocAhb(const VkImageCreateInfo* imageCreateInfo) {
+    // Map VkFormat to the corresponding AHB format — must match to avoid tiling mismatch.
+    uint32_t ahbFormat;
+    switch (imageCreateInfo->format) {
+        case VK_FORMAT_B8G8R8A8_UNORM:
+        case VK_FORMAT_B8G8R8A8_SRGB:
+            ahbFormat = 5;  // AHARDWAREBUFFER_FORMAT_B8G8R8A8_UNORM
+            break;
+        case VK_FORMAT_R8G8B8A8_UNORM:
+        case VK_FORMAT_R8G8B8A8_SRGB:
+        default:
+            ahbFormat = AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM;
+            break;
+    }
+
+    // Translate the common VkImageUsageFlagBits into their corresponding AHB usage bits.
+    uint64_t ahbUsage = 0;
+    const VkImageUsageFlags vkUsage = imageCreateInfo->usage;
+    if (vkUsage & VK_IMAGE_USAGE_SAMPLED_BIT) {
+        ahbUsage |= AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE;
+    }
+    if (vkUsage & (VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
+                   VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT |
+                   VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT)) {
+        ahbUsage |= AHARDWAREBUFFER_USAGE_GPU_FRAMEBUFFER;
+    }
+    if (vkUsage & VK_IMAGE_USAGE_STORAGE_BIT) {
+        ahbUsage |= AHARDWAREBUFFER_USAGE_GPU_DATA_BUFFER;
+    }
+    // ColorBuffers are always at least framebuffer/sampled-capable; default to a usable
+    // combination if the image declared no GPU-relevant usage.
+    if (ahbUsage == 0) {
+        ahbUsage = AHARDWAREBUFFER_USAGE_GPU_FRAMEBUFFER | AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE;
+    }
+
+    AHardwareBuffer_Desc desc = {
+        .width = imageCreateInfo->extent.width,
+        .height = imageCreateInfo->extent.height,
+        .layers = 1,
+        .format = ahbFormat,
+        .usage = ahbUsage,
+    };
+
+    AHardwareBuffer* ahb = nullptr;
+    int ahbRes = AHardwareBuffer_allocate(&desc, &ahb);
+    if (ahbRes != 0 || !ahb) {
+        GFXSTREAM_WARNING("AHardwareBuffer_allocate failed (err=%d) for %ux%u.", ahbRes,
+                          imageCreateInfo->extent.width, imageCreateInfo->extent.height);
+        return nullptr;
+    }
+    return ahb;
+}
+#endif
+
 // Precondition: sVkEmulation has valid device support info
 bool VkEmulation::allocExternalMemory(VulkanDispatch* vk, VkEmulation::ExternalMemoryInfo* info,
                                       Optional<uint64_t> deviceAlignment,
@@ -2091,12 +2153,24 @@ bool VkEmulation::allocExternalMemory(VulkanDispatch* vk, VkEmulation::ExternalM
         .buffer = nullptr,
     };
 #endif
+#ifdef __ANDROID__
+    // Declared here (not inside the AndroidAHB switch case) so it outlives the
+    // vkAllocateMemory call below: vk_append_struct() stores a pointer to it in
+    // allocInfoChain, which is only consumed at allocation time.
+    VkImportAndroidHardwareBufferInfoANDROID importAhbInfo = {
+        .sType = VK_STRUCTURE_TYPE_IMPORT_ANDROID_HARDWARE_BUFFER_INFO_ANDROID,
+        .pNext = nullptr,
+        .buffer = nullptr,
+    };
+#endif
 
     auto allocInfoChain = vk_make_chain_iterator(&allocInfo);
 
-    // HostAllocation mode uses host side allocation and should not add VkExportMemoryAllocateInfo
+    // HostAllocation mode uses host side allocation and should not add VkExportMemoryAllocateInfo.
+    // AndroidAHB mode uses AHardwareBuffer_allocate + import instead of export (see switch below).
     if (mDeviceInfo.supportsExternalMemoryExport &&
-        getExternalMemoryMode() != ExternalMemory::Mode::HostAllocation) {
+        getExternalMemoryMode() != ExternalMemory::Mode::HostAllocation &&
+        getExternalMemoryMode() != ExternalMemory::Mode::AndroidAHB) {
         exportAi.handleTypes =
             static_cast<VkExternalMemoryHandleTypeFlags>(getDefaultExternalMemoryHandleType());
 
@@ -2256,6 +2330,80 @@ bool VkEmulation::allocExternalMemory(VulkanDispatch* vk, VkEmulation::ExternalM
             break;
         }
 #endif
+        case ExternalMemory::Mode::AndroidAHB: {
+#ifdef __ANDROID__
+            // Prefer allocating the AHardwareBuffer via Gralloc and import to work around
+            // Vulkan drivers which are unable to export until after `vkBindImageMemory()`
+            // (e.g. b/516865218). AHB allocate+import is the standard path on Android and
+            // works on both mobile GPUs and the affected drivers. If any step below fails,
+            // we break and fall back to the default (non-AHB) allocation path.
+            if (colorBufferInfo) {
+                auto cbInfoPtr = *colorBufferInfo;
+
+                AHardwareBuffer* ahb = allocAhb(&cbInfoPtr->imageCreateInfoShallow);
+                if (!ahb) {
+                    GFXSTREAM_WARNING(
+                        "Falling back to non-exportable allocation for ColorBuffer %u (%ux%u).",
+                        cbInfoPtr->handle, cbInfoPtr->width, cbInfoPtr->height);
+                    break;
+                }
+
+                // Query Vulkan properties of the AHB
+                VkAndroidHardwareBufferPropertiesANDROID ahbProps = {
+                    .sType = VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_PROPERTIES_ANDROID,
+                };
+                VkResult propsRes = vk->vkGetAndroidHardwareBufferPropertiesANDROID(
+                    mDevice, ahb, &ahbProps);
+                if (propsRes != VK_SUCCESS) {
+                    GFXSTREAM_WARNING(
+                        "vkGetAndroidHardwareBufferPropertiesANDROID failed: %s. "
+                        "Falling back to non-exportable allocation.",
+                        string_VkResult(propsRes));
+                    AHardwareBuffer_release(ahb);
+                    break;
+                }
+
+                // Find a memory type that satisfies both the image and AHB requirements
+                uint32_t combinedBits = ahbProps.memoryTypeBits &
+                                        cbInfoPtr->imageMemReqs.memoryTypeBits;
+                if (!combinedBits) {
+                    GFXSTREAM_WARNING(
+                        "No common memory type for AHB (0x%x) and image (0x%x). "
+                        "Falling back to non-exportable allocation.",
+                        ahbProps.memoryTypeBits, cbInfoPtr->imageMemReqs.memoryTypeBits);
+                    AHardwareBuffer_release(ahb);
+                    break;
+                }
+
+                // Pick a device-local memory type from the combined bits
+                info->typeIndex = getValidMemoryTypeIndex(combinedBits, cbInfoPtr->memoryProperty);
+                allocInfo.memoryTypeIndex = info->typeIndex;
+                info->size = ahbProps.allocationSize;
+                allocInfo.allocationSize = ahbProps.allocationSize;
+
+                // Chain the import info (declared at function scope above so it outlives
+                // the vkAllocateMemory call that consumes allocInfoChain).
+                importAhbInfo.buffer = ahb;
+                vk_append_struct(&allocInfoChain, &importAhbInfo);
+
+                // Store the AHB handle for lifetime management (released in freeExternalMemoryLocked)
+                info->handleInfo = ExternalHandleInfo{
+                    .handle = reinterpret_cast<ExternalHandleType>(ahb),
+                    .streamHandleType = STREAM_HANDLE_TYPE_PLATFORM_AHB,
+                };
+                cbInfoPtr->externalMemoryCompatible = true;
+
+                GFXSTREAM_DEBUG(
+                    "ColorBuffer %u: imported AHB (%ux%u, format=%s) into Vulkan "
+                    "(memoryTypeIndex=%u, size=%" PRIu64 ")",
+                    cbInfoPtr->handle, cbInfoPtr->width, cbInfoPtr->height,
+                    string_VkFormat(cbInfoPtr->imageCreateInfoShallow.format), info->typeIndex,
+                    (uint64_t)ahbProps.allocationSize);
+            }
+#endif
+            break;
+        }
+
         default:
             // The default behavior is exporting the memory using some getMemory() function
             // interface after allocation.
@@ -2382,20 +2530,28 @@ bool VkEmulation::allocExternalMemory(VulkanDispatch* vk, VkEmulation::ExternalM
 
         case ExternalMemory::Mode::AndroidAHB: {
 #ifdef __ANDROID__
-            VkMemoryGetAndroidHardwareBufferInfoANDROID getAhbInfo = {
-                .sType = VK_STRUCTURE_TYPE_MEMORY_GET_ANDROID_HARDWARE_BUFFER_INFO_ANDROID,
-                .pNext = nullptr,
-                .memory = info->memory,
-            };
-            AHardwareBuffer* exportHandle =
-                static_cast<AHardwareBuffer*>(reinterpret_cast<void*>(info->handleInfo->handle));
-            exportRes =
-                vk->vkGetMemoryAndroidHardwareBufferANDROID(mDevice, &getAhbInfo, &exportHandle);
-            validHandle = (VK_SUCCESS == exportRes) && (NULL != exportHandle);
-            info->handleInfo = ExternalHandleInfo{
-                .handle = reinterpret_cast<ExternalHandleType>(exportHandle),
-                .streamHandleType = STREAM_HANDLE_TYPE_PLATFORM_AHB,
-            };
+            // If the AHB was already allocated and imported (via AHardwareBuffer_allocate
+            // in the pre-allocation switch above), handleInfo is already set. Skip export.
+            if (info->handleInfo &&
+                info->handleInfo->streamHandleType == STREAM_HANDLE_TYPE_PLATFORM_AHB) {
+                validHandle = true;
+                exportRes = VK_SUCCESS;
+            } else {
+                // Fallback: use the old export path if AHB import wasn't used
+                VkMemoryGetAndroidHardwareBufferInfoANDROID getAhbInfo = {
+                    .sType = VK_STRUCTURE_TYPE_MEMORY_GET_ANDROID_HARDWARE_BUFFER_INFO_ANDROID,
+                    .pNext = nullptr,
+                    .memory = info->memory,
+                };
+                AHardwareBuffer* exportHandle = nullptr;
+                exportRes =
+                    vk->vkGetMemoryAndroidHardwareBufferANDROID(mDevice, &getAhbInfo, &exportHandle);
+                validHandle = (VK_SUCCESS == exportRes) && (NULL != exportHandle);
+                info->handleInfo = ExternalHandleInfo{
+                    .handle = reinterpret_cast<ExternalHandleType>(exportHandle),
+                    .streamHandleType = STREAM_HANDLE_TYPE_PLATFORM_AHB,
+                };
+            }
 #endif
             break;
         }


### PR DESCRIPTION
## Summary
Back ColorBuffers with `AHardwareBuffer_allocate()` + `VkImportAndroidHardwareBufferInfoANDROID` instead of allocating via Vulkan and exporting with `vkGetMemoryAndroidHardwareBufferANDROID`.

The Vulkan export path fails on drivers that defer image-layout initialization until `vkBindImageMemory` (returning `size=0` from `vkGetImageMemoryRequirements` for AHB-compatible images). The import path works because gralloc owns the allocation and the driver resolves the layout from the AHB at bind time. AHB allocate + import is the standard ColorBuffer path on Android, so it is done unconditionally for `AndroidAHB` mode (with a fallback to the default allocation path if any AHB step fails).

### Key changes
- `allocExternalMemory()`: for `AndroidAHB` mode, always allocate the AHB (format matched to the VkImage format) and import it; fall back to default allocation on failure.
- New `allocAhb(const VkImageCreateInfo*)` helper that maps `VkFormat` + the common `VkImageUsageFlagBits` to the AHB description (keeps `allocExternalMemory` from growing).
- Skip `VkExportMemoryAllocateInfo` for `AndroidAHB` mode (not needed when importing).
- `Android.bp`: add `libnativewindow` for the `AHardwareBuffer` APIs.

## Testing
DUT-verified on fatcat (Intel Panther Lake): Debian VM boots with the gfxstream GPU backend, weston is active, and `vkcube` renders end-to-end through the gfxstream Vulkan ICD on the host GPU. No display distortion and no ColorBuffer allocation abort.

Bug: 516865218
