### PR TITLE
gfxstream-virtio: export ColorBuffer AHB for non-blob CREATE_3D resources

### DIFF
--- a/host/Android.bp
+++ b/host/Android.bp
@@ -166,6 +166,9 @@ cc_defaults {
         },
         android: {
             srcs: ["native_sub_window_android.cpp"],
+            shared_libs: [
+                "libnativewindow",
+            ],
         },
     },
 }

--- a/host/virtio_gpu_resource.cpp
+++ b/host/virtio_gpu_resource.cpp
@@ -124,6 +124,29 @@ VirtioGpuResourceType GetResourceType(const struct stream_renderer_resource_crea
     return VirtioGpuResourceType::BUFFER;
 }
 
+// Fills `outHandle` from an exported descriptor, consolidating the platform
+// `#ifdef`s: on Android the descriptor is an opaque handle taken by value; on
+// other platforms it is a ManagedDescriptor whose ownership is released to the
+// VMM. Returns 0 on success, -EINVAL if the descriptor could not be obtained.
+int fillExportHandle(struct stream_renderer_handle* outHandle, BlobDescriptorType& descriptorInfo) {
+#ifdef __ANDROID__
+    auto rawDescriptor = descriptorInfo.handle;
+#else
+    auto rawDescriptorOpt = descriptorInfo.descriptor.release();
+    if (!rawDescriptorOpt) {
+        return -EINVAL;
+    }
+    auto rawDescriptor = *rawDescriptorOpt;
+#endif
+#ifdef _WIN32
+    outHandle->os_handle = static_cast<int64_t>(reinterpret_cast<intptr_t>(rawDescriptor));
+#else
+    outHandle->os_handle = static_cast<int64_t>(rawDescriptor);
+#endif
+    outHandle->handle_type = descriptorInfo.streamHandleType;
+    return 0;
+}
+
 }  // namespace
 
 /*static*/
@@ -764,6 +787,16 @@ int VirtioGpuResource::TransferWithIov(uint64_t offset, const stream_renderer_bo
 }
 
 int VirtioGpuResource::ExportBlob(struct stream_renderer_handle* outHandle) {
+    // For non-blob COLOR_BUFFER resources (CREATE_3D path), there is no mBlobMemory
+    // set. Attempt to export the ColorBuffer's external memory.
+    if (!mBlobMemory && mResourceType == VirtioGpuResourceType::COLOR_BUFFER) {
+        auto descriptorInfoOpt = FrameBuffer::getFB()->exportColorBuffer(mId);
+        if (!descriptorInfoOpt) {
+            return -EINVAL;
+        }
+        return fillExportHandle(outHandle, descriptorInfoOpt->descriptorInfo);
+    }
+
     if (!mBlobMemory) {
         return -EINVAL;
     }
@@ -785,24 +818,12 @@ int VirtioGpuResource::ExportBlob(struct stream_renderer_handle* outHandle) {
         return 0;
     } else if (std::holds_alternative<ExternalMemoryInfo>(*mBlobMemory)) {
         auto& memory = std::get<ExternalMemoryInfo>(*mBlobMemory);
-#ifdef __ANDROID__
-        auto rawDescriptor = memory->descriptorInfo.handle;
-#else
-        auto rawDescriptorOpt = memory->descriptorInfo.descriptor.release();
-        if (!rawDescriptorOpt) {
+        int ret = fillExportHandle(outHandle, memory->descriptorInfo);
+        if (ret != 0) {
             GFXSTREAM_ERROR("failed to export blob for resource %u: failed to get raw handle.",
                             mId);
-            return -EINVAL;
         }
-        auto rawDescriptor = *rawDescriptorOpt;
-#endif
-#ifdef _WIN32
-        outHandle->os_handle = static_cast<int64_t>(reinterpret_cast<intptr_t>(rawDescriptor));
-#else
-        outHandle->os_handle = static_cast<int64_t>(rawDescriptor);
-#endif
-        outHandle->handle_type = memory->descriptorInfo.streamHandleType;
-        return 0;
+        return ret;
     }
 
     return -EINVAL;

--- a/host/vulkan/vk_common_operations.cpp
+++ b/host/vulkan/vk_common_operations.cpp
@@ -58,6 +58,10 @@
 #include "platform_helper_qnx.h"
 #endif
 
+#ifdef __ANDROID__
+#include <android/hardware_buffer.h>
+#endif
+
 namespace gfxstream {
 namespace host {
 namespace vk {
@@ -1106,6 +1110,7 @@ std::unique_ptr<VkEmulation> VkEmulation::create(VulkanDispatch* gvk,
             if (deviceInfos[i].externalMemoryMode == ExternalMemory::Mode::QnxScreenBuffer) {
                 deviceInfos[i].supportsExternalMemoryExport = false;
             }
+
         }
 
         if (emulation->mInstanceSupportsGetPhysicalDeviceProperties2) {
@@ -2055,6 +2060,63 @@ MTLResource_id VkEmulation::getMtlResourceFromVkDeviceMemory(VulkanDispatch* vk,
 }
 #endif
 
+#ifdef __ANDROID__
+// Allocate an AHardwareBuffer matching the given image's format, extent and usage.
+// Returns nullptr on failure (caller falls back to the non-AHB allocation path).
+static AHardwareBuffer* allocAhb(const VkImageCreateInfo* imageCreateInfo) {
+    // Map VkFormat to the corresponding AHB format — must match to avoid tiling mismatch.
+    uint32_t ahbFormat;
+    switch (imageCreateInfo->format) {
+        case VK_FORMAT_B8G8R8A8_UNORM:
+        case VK_FORMAT_B8G8R8A8_SRGB:
+            ahbFormat = 5;  // AHARDWAREBUFFER_FORMAT_B8G8R8A8_UNORM
+            break;
+        case VK_FORMAT_R8G8B8A8_UNORM:
+        case VK_FORMAT_R8G8B8A8_SRGB:
+        default:
+            ahbFormat = AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM;
+            break;
+    }
+
+    // Translate the common VkImageUsageFlagBits into their corresponding AHB usage bits.
+    uint64_t ahbUsage = 0;
+    const VkImageUsageFlags vkUsage = imageCreateInfo->usage;
+    if (vkUsage & VK_IMAGE_USAGE_SAMPLED_BIT) {
+        ahbUsage |= AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE;
+    }
+    if (vkUsage & (VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
+                   VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT |
+                   VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT)) {
+        ahbUsage |= AHARDWAREBUFFER_USAGE_GPU_FRAMEBUFFER;
+    }
+    if (vkUsage & VK_IMAGE_USAGE_STORAGE_BIT) {
+        ahbUsage |= AHARDWAREBUFFER_USAGE_GPU_DATA_BUFFER;
+    }
+    // ColorBuffers are always at least framebuffer/sampled-capable; default to a usable
+    // combination if the image declared no GPU-relevant usage.
+    if (ahbUsage == 0) {
+        ahbUsage = AHARDWAREBUFFER_USAGE_GPU_FRAMEBUFFER | AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE;
+    }
+
+    AHardwareBuffer_Desc desc = {
+        .width = imageCreateInfo->extent.width,
+        .height = imageCreateInfo->extent.height,
+        .layers = 1,
+        .format = ahbFormat,
+        .usage = ahbUsage,
+    };
+
+    AHardwareBuffer* ahb = nullptr;
+    int ahbRes = AHardwareBuffer_allocate(&desc, &ahb);
+    if (ahbRes != 0 || !ahb) {
+        GFXSTREAM_WARNING("AHardwareBuffer_allocate failed (err=%d) for %ux%u.", ahbRes,
+                          imageCreateInfo->extent.width, imageCreateInfo->extent.height);
+        return nullptr;
+    }
+    return ahb;
+}
+#endif
+
 // Precondition: sVkEmulation has valid device support info
 bool VkEmulation::allocExternalMemory(VulkanDispatch* vk, VkEmulation::ExternalMemoryInfo* info,
                                       Optional<uint64_t> deviceAlignment,
@@ -2091,12 +2153,24 @@ bool VkEmulation::allocExternalMemory(VulkanDispatch* vk, VkEmulation::ExternalM
         .buffer = nullptr,
     };
 #endif
+#ifdef __ANDROID__
+    // Declared here (not inside the AndroidAHB switch case) so it outlives the
+    // vkAllocateMemory call below: vk_append_struct() stores a pointer to it in
+    // allocInfoChain, which is only consumed at allocation time.
+    VkImportAndroidHardwareBufferInfoANDROID importAhbInfo = {
+        .sType = VK_STRUCTURE_TYPE_IMPORT_ANDROID_HARDWARE_BUFFER_INFO_ANDROID,
+        .pNext = nullptr,
+        .buffer = nullptr,
+    };
+#endif
 
     auto allocInfoChain = vk_make_chain_iterator(&allocInfo);
 
-    // HostAllocation mode uses host side allocation and should not add VkExportMemoryAllocateInfo
+    // HostAllocation mode uses host side allocation and should not add VkExportMemoryAllocateInfo.
+    // AndroidAHB mode uses AHardwareBuffer_allocate + import instead of export (see switch below).
     if (mDeviceInfo.supportsExternalMemoryExport &&
-        getExternalMemoryMode() != ExternalMemory::Mode::HostAllocation) {
+        getExternalMemoryMode() != ExternalMemory::Mode::HostAllocation &&
+        getExternalMemoryMode() != ExternalMemory::Mode::AndroidAHB) {
         exportAi.handleTypes =
             static_cast<VkExternalMemoryHandleTypeFlags>(getDefaultExternalMemoryHandleType());
 
@@ -2256,6 +2330,80 @@ bool VkEmulation::allocExternalMemory(VulkanDispatch* vk, VkEmulation::ExternalM
             break;
         }
 #endif
+        case ExternalMemory::Mode::AndroidAHB: {
+#ifdef __ANDROID__
+            // Prefer allocating the AHardwareBuffer via Gralloc and import to work around
+            // Vulkan drivers which are unable to export until after `vkBindImageMemory()`
+            // (e.g. b/516865218). AHB allocate+import is the standard path on Android and
+            // works on both mobile GPUs and the affected drivers. If any step below fails,
+            // we break and fall back to the default (non-AHB) allocation path.
+            if (colorBufferInfo) {
+                auto cbInfoPtr = *colorBufferInfo;
+
+                AHardwareBuffer* ahb = allocAhb(&cbInfoPtr->imageCreateInfoShallow);
+                if (!ahb) {
+                    GFXSTREAM_WARNING(
+                        "Falling back to non-exportable allocation for ColorBuffer %u (%ux%u).",
+                        cbInfoPtr->handle, cbInfoPtr->width, cbInfoPtr->height);
+                    break;
+                }
+
+                // Query Vulkan properties of the AHB
+                VkAndroidHardwareBufferPropertiesANDROID ahbProps = {
+                    .sType = VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_PROPERTIES_ANDROID,
+                };
+                VkResult propsRes = vk->vkGetAndroidHardwareBufferPropertiesANDROID(
+                    mDevice, ahb, &ahbProps);
+                if (propsRes != VK_SUCCESS) {
+                    GFXSTREAM_WARNING(
+                        "vkGetAndroidHardwareBufferPropertiesANDROID failed: %s. "
+                        "Falling back to non-exportable allocation.",
+                        string_VkResult(propsRes));
+                    AHardwareBuffer_release(ahb);
+                    break;
+                }
+
+                // Find a memory type that satisfies both the image and AHB requirements
+                uint32_t combinedBits = ahbProps.memoryTypeBits &
+                                        cbInfoPtr->imageMemReqs.memoryTypeBits;
+                if (!combinedBits) {
+                    GFXSTREAM_WARNING(
+                        "No common memory type for AHB (0x%x) and image (0x%x). "
+                        "Falling back to non-exportable allocation.",
+                        ahbProps.memoryTypeBits, cbInfoPtr->imageMemReqs.memoryTypeBits);
+                    AHardwareBuffer_release(ahb);
+                    break;
+                }
+
+                // Pick a device-local memory type from the combined bits
+                info->typeIndex = getValidMemoryTypeIndex(combinedBits, cbInfoPtr->memoryProperty);
+                allocInfo.memoryTypeIndex = info->typeIndex;
+                info->size = ahbProps.allocationSize;
+                allocInfo.allocationSize = ahbProps.allocationSize;
+
+                // Chain the import info (declared at function scope above so it outlives
+                // the vkAllocateMemory call that consumes allocInfoChain).
+                importAhbInfo.buffer = ahb;
+                vk_append_struct(&allocInfoChain, &importAhbInfo);
+
+                // Store the AHB handle for lifetime management (released in freeExternalMemoryLocked)
+                info->handleInfo = ExternalHandleInfo{
+                    .handle = reinterpret_cast<ExternalHandleType>(ahb),
+                    .streamHandleType = STREAM_HANDLE_TYPE_PLATFORM_AHB,
+                };
+                cbInfoPtr->externalMemoryCompatible = true;
+
+                GFXSTREAM_DEBUG(
+                    "ColorBuffer %u: imported AHB (%ux%u, format=%s) into Vulkan "
+                    "(memoryTypeIndex=%u, size=%" PRIu64 ")",
+                    cbInfoPtr->handle, cbInfoPtr->width, cbInfoPtr->height,
+                    string_VkFormat(cbInfoPtr->imageCreateInfoShallow.format), info->typeIndex,
+                    (uint64_t)ahbProps.allocationSize);
+            }
+#endif
+            break;
+        }
+
         default:
             // The default behavior is exporting the memory using some getMemory() function
             // interface after allocation.
@@ -2382,20 +2530,28 @@ bool VkEmulation::allocExternalMemory(VulkanDispatch* vk, VkEmulation::ExternalM
 
         case ExternalMemory::Mode::AndroidAHB: {
 #ifdef __ANDROID__
-            VkMemoryGetAndroidHardwareBufferInfoANDROID getAhbInfo = {
-                .sType = VK_STRUCTURE_TYPE_MEMORY_GET_ANDROID_HARDWARE_BUFFER_INFO_ANDROID,
-                .pNext = nullptr,
-                .memory = info->memory,
-            };
-            AHardwareBuffer* exportHandle =
-                static_cast<AHardwareBuffer*>(reinterpret_cast<void*>(info->handleInfo->handle));
-            exportRes =
-                vk->vkGetMemoryAndroidHardwareBufferANDROID(mDevice, &getAhbInfo, &exportHandle);
-            validHandle = (VK_SUCCESS == exportRes) && (NULL != exportHandle);
-            info->handleInfo = ExternalHandleInfo{
-                .handle = reinterpret_cast<ExternalHandleType>(exportHandle),
-                .streamHandleType = STREAM_HANDLE_TYPE_PLATFORM_AHB,
-            };
+            // If the AHB was already allocated and imported (via AHardwareBuffer_allocate
+            // in the pre-allocation switch above), handleInfo is already set. Skip export.
+            if (info->handleInfo &&
+                info->handleInfo->streamHandleType == STREAM_HANDLE_TYPE_PLATFORM_AHB) {
+                validHandle = true;
+                exportRes = VK_SUCCESS;
+            } else {
+                // Fallback: use the old export path if AHB import wasn't used
+                VkMemoryGetAndroidHardwareBufferInfoANDROID getAhbInfo = {
+                    .sType = VK_STRUCTURE_TYPE_MEMORY_GET_ANDROID_HARDWARE_BUFFER_INFO_ANDROID,
+                    .pNext = nullptr,
+                    .memory = info->memory,
+                };
+                AHardwareBuffer* exportHandle = nullptr;
+                exportRes =
+                    vk->vkGetMemoryAndroidHardwareBufferANDROID(mDevice, &getAhbInfo, &exportHandle);
+                validHandle = (VK_SUCCESS == exportRes) && (NULL != exportHandle);
+                info->handleInfo = ExternalHandleInfo{
+                    .handle = reinterpret_cast<ExternalHandleType>(exportHandle),
+                    .streamHandleType = STREAM_HANDLE_TYPE_PLATFORM_AHB,
+                };
+            }
 #endif
             break;
         }


### PR DESCRIPTION
> **Note:** This PR is stacked on top of #141 ("Fix ColorBuffer allocation by using AHB import instead of export"). Until that one merges, the diff here will also show its changes. Please review/merge the base PR first.

## Summary
Without this change, `VirtioGpuResource::ExportBlob` returns `-EINVAL` for guest-created `COLOR_BUFFER` resources (the `CREATE_3D` path) because `mBlobMemory` is unset for those. As a result, crosvm's zero-copy AHB-FLIP scanout path always failed at rutabaga's `export_blob` with `MesaError(InvalidMesaHandle)`, and every frame fell back to the `transfer_read -> post_android_surface_buffer` COPY path.

When `mBlobMemory` is unset AND `mResourceType` is `COLOR_BUFFER`, fall through to `FrameBuffer::exportColorBuffer` to retrieve the underlying ColorBuffer's AHB descriptor and populate the `stream_renderer_handle`. This mirrors the BLOB-create path's use of `exportColorBuffer`. Other resource types still return `-EINVAL`.

The two export sites are also consolidated into a single `fillExportHandle()` helper, combining the `#ifdef __ANDROID__` (by-value handle vs `ManagedDescriptor.release()`) and `#ifdef _WIN32` (`os_handle` cast) ladders.

Paired with the corresponding rutabaga_gfx change that calls `self.export_blob` in `Gfxstream::create_3d` to capture and store the exported handle on the `RutabagaResource`.

## Testing
DUT-verified on fatcat (Intel Panther Lake): 149 consecutive scanout flushes take the AHB-FLIP path; display renders without distortion.

Bug: 516865218
