### PR TITLE
vulkan: Validate offset and size in buffer read/update transfers

### DIFF
--- a/host/vulkan/vk_common_operations.cpp
+++ b/host/vulkan/vk_common_operations.cpp
@@ -4634,6 +4634,13 @@ bool VkEmulation::readBufferToBytes(uint32_t bufferHandle, uint64_t offset, uint
         return false;
     }
 
+    if (offset > bufferInfo->size || size > bufferInfo->size - offset) {
+        GFXSTREAM_ERROR("Failed to read from Buffer:%d, [offset %" PRIu64 ", size %" PRIu64
+                        "] out of range of buffer size %" PRIu64 ".",
+                        bufferHandle, offset, size, bufferInfo->size);
+        return false;
+    }
+
     const auto& stagingBufferInfo = mStaging;
     if (size > stagingBufferInfo.mAllocationSize) {
         GFXSTREAM_ERROR("Failed to read from Buffer:%d, staging buffer too small.", bufferHandle);
@@ -4717,6 +4724,13 @@ bool VkEmulation::updateBufferFromBytes(uint32_t bufferHandle, uint64_t offset, 
     auto bufferInfo = gfxstream::base::find(mBuffers, bufferHandle);
     if (!bufferInfo) {
         GFXSTREAM_ERROR("Failed to update Buffer:%d, not found.", bufferHandle);
+        return false;
+    }
+
+    if (offset > bufferInfo->size || size > bufferInfo->size - offset) {
+        GFXSTREAM_ERROR("Failed to update Buffer:%d, [offset %" PRIu64 ", size %" PRIu64
+                        "] out of range of buffer size %" PRIu64 ".",
+                        bufferHandle, offset, size, bufferInfo->size);
         return false;
     }
 


### PR DESCRIPTION
VkEmulation::readBufferToBytes() and updateBufferFromBytes() take a guest-supplied offset and size and copy that range to/from the target VkBuffer via vkCmdCopyBuffer at srcOffset/dstOffset = offset. They already reject a size larger than the staging buffer, but never check the range against the target buffer's own size, so a guest can drive vkCmdCopyBuffer to read or write past the end of the buffer's backing memory. This is the same class of check added in commit 195344f for the staging buffer.

Add a bounds check that rejects the transfer when offset or offset+size exceeds bufferInfo->size, using subtraction to avoid overflow in the offset+size computation.

Test: bazel build //host/vulkan:gfxstream_vulkan_server