### PR TITLE
vulkan: Fix argument list in scaled readback failure log

### DIFF
--- a/host/vulkan/vk_common_operations.cpp
+++ b/host/vulkan/vk_common_operations.cpp
@@ -3664,7 +3664,7 @@ bool VkEmulation::readColorBufferPixelsScaledCpu(uint32_t colorBufferHandle, int
                                       readback_r8g8b8a8.data(), readback_r8g8b8a8.size())) {
         // Could not readback, cannot continue for resizing
         GFXSTREAM_ERROR("%s: Failed to readback color buffer %d (%" PRIu64 "x%" PRIu64 ", %s)",
-                        colorBufferHandle, readbackWidth, readbackHeight,
+                        __func__, colorBufferHandle, readbackWidth, readbackHeight,
                         ToString(colorBufferInfo->format).c_str());
         return false;
     }


### PR DESCRIPTION
The error logged when readColorBufferToBytesLocked() fails in readColorBufferPixelsScaledCpu() has a leading "%s:" format specifier but was missing the corresponding __func__ argument, so colorBufferHandle was consumed by "%s" (reading a uint32_t as a char*) and every following specifier was fed the wrong argument, ending in a read past the argument list for the trailing "%s". Pass __func__ first, matching the sibling resize-failure log a few lines below.

Test: bazel build //host/vulkan:gfxstream_vulkan_server