### PR TITLE
qnx: Fix critical issues with platform_helper_qnx.cpp string handling

### DIFF
--- a/host/platform_helper_qnx.cpp
+++ b/host/platform_helper_qnx.cpp
@@ -95,7 +95,7 @@ std::optional<std::pair<screen_stream_t, screen_buffer_t>> createScreenStreamBuf
         GFXSTREAM_ERROR(
             "Could not create buffer for screen_stream_t (usage=0x%x, id_str=%s, width=%d, "
             "height=%d, format=%d)\n",
-            screenUsage, bufferName.c_str(), width, height, format);
+            screenUsage, bufferName.c_str(), width, height, screenFormat);
         return std::nullopt;
     }
 

--- a/host/vulkan/vk_common_operations.cpp
+++ b/host/vulkan/vk_common_operations.cpp
@@ -2255,7 +2255,7 @@ bool VkEmulation::allocExternalMemory(VulkanDispatch* vk, VkEmulation::ExternalM
                 // So, do server-side allocation first, then import to Vulkan.
                 // Note: External memory is only supported for ColorBuffers, in this case.
                 auto cbInfoPtr = *colorBufferInfo;
-                std::string bufferName = "VkColorBuffer-" + cbInfoPtr->handle;
+                std::string bufferName = std::string("VkColorBuffer-") + std::to_string(cbInfoPtr->handle);
                 auto screenStreamBuffer = gfxstream::qnx::createScreenStreamBuffer(
                     cbInfoPtr->width, cbInfoPtr->height, cbInfoPtr->format, bufferName);
                 if (!screenStreamBuffer) {


### PR DESCRIPTION
Some undefined behavior in the `platform_helper_qnx` implementation that somehow wasn't caught before ... :slightly_frowning_face: 