### PR TITLE
macOS: fix host build, SHM names and createBlob failures; add presubmit job

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -102,6 +102,23 @@ jobs:
       run: |
         meson compile -C build
 
+  run-gfxstream-meson-build-macos:
+    runs-on: macos-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+    - name: Install toolchain dependencies
+      run: brew install meson ninja molten-vk vulkan-loader
+    - name: Configure Build
+      run: |
+        meson setup \
+          -Ddefault_library=static \
+          -Dgfxstream-build=host \
+          build
+    - name: Build
+      run: |
+        meson compile -C build
+
   run-gfxstream-meson-build-windows:
     runs-on: windows-latest
     defaults:

--- a/common/base/SharedMemory_posix.cpp
+++ b/common/base/SharedMemory_posix.cpp
@@ -55,7 +55,10 @@ SharedMemory::SharedMemory(const std::string& name, size_t size) {
         mName = PathUtils::recompose(PathUtils::decompose(std::move(path)));
     } else {
         mShareType = ShareType::SHARED_MEMORY;
-        mName = name;
+        // POSIX.1-2017 (System Interfaces) requires shm_open() names to begin
+        // with a '/' character to avoid implementation-defined behavior.
+        // Normalize unconditionally so callers don't need to care about it.
+        mName = (!name.empty() && name[0] != '/') ? ("/" + name) : name;
     }
 }
 
@@ -111,7 +114,9 @@ int SharedMemory::openInternal(int oflag, int mode, bool doMapping) {
     int err = 0;
     struct stat sb;
     if (mShareType == ShareType::SHARED_MEMORY) {
-#if defined(HAVE_MEMFD_CREATE)
+#if defined(__APPLE__)
+        mFd = ::shm_open(mName.c_str(), oflag, mode);
+#elif defined(HAVE_MEMFD_CREATE)
         mFd = memfd_create(mName.c_str(), MFD_CLOEXEC | MFD_ALLOW_SEALING);
 #else
         mFd = syscall(__NR_memfd_create, mName.c_str(), FD_CLOEXEC);

--- a/host/color_buffer.cpp
+++ b/host/color_buffer.cpp
@@ -27,7 +27,9 @@ namespace gfxstream {
 namespace host {
 namespace {
 
+#if GFXSTREAM_ENABLE_HOST_GLES
 using gl::ColorBufferGl;
+#endif
 using vk::ColorBufferVk;
 
 // ColorBufferVk natively supports YUV images. However, ColorBufferGl
@@ -158,7 +160,11 @@ std::unique_ptr<ColorBuffer::Impl> ColorBuffer::Impl::create(
 #endif
 
     if (emulationVk) {
+#if GFXSTREAM_ENABLE_HOST_GLES
         const bool vulkanOnly = colorBuffer->mColorBufferGl == nullptr;
+#else
+        const bool vulkanOnly = true;
+#endif
         const uint32_t memoryProperty = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
         const uint32_t mipLevels = 1;
         colorBuffer->mColorBufferVk = vk::ColorBufferVk::create(

--- a/host/frame_buffer.h
+++ b/host/frame_buffer.h
@@ -25,7 +25,7 @@
 #include <GLES2/gl2.h>
 #include <GLES2/gl2ext.h>
 #else
-#include "GlesCompat.h"
+#include "gles_compat.h"
 #endif  // GFXSTREAM_ENABLE_HOST_GLES
 #include <vulkan/vulkan.h>
 

--- a/host/gl/meson.build
+++ b/host/gl/meson.build
@@ -1,12 +1,6 @@
 # Copyright 2023 Android Open Source Project
 # SPDX-License-Identifier: Apache-2.0
 
-inc_gl_server = include_directories('.')
-inc_gl_snapshot = include_directories('glsnapshot')
-
-# Needs forward declaration.
-inc_gl_openglesdispatch = include_directories('OpenGLESDispatch/include')
-
 # GLES translator
 subdir('glestranslator')
 

--- a/host/gles_compat.h
+++ b/host/gles_compat.h
@@ -19,7 +19,10 @@
 
 typedef unsigned int GLenum;
 typedef int32_t EGLint;
-typedef unsigned int EGLNativeWindowType;
+// Must stay ABI-compatible with the real EGLNativeWindowType from
+// <EGL/eglplatform.h>, which is pointer-sized on 64-bit platforms
+// (e.g. `void*` on Apple); a 32-bit integer here truncates pointers.
+typedef void* EGLNativeWindowType;
 
 namespace gfxstream {
 namespace gl {

--- a/host/iostream/iostream_stub.cpp
+++ b/host/iostream/iostream_stub.cpp
@@ -1,0 +1,2 @@
+// Intentionally empty: macOS ar(1) refuses to create an archive with no
+// members, so Darwin builds need at least one translation unit here.

--- a/host/iostream/meson.build
+++ b/host/iostream/meson.build
@@ -5,6 +5,10 @@ inc_host_iostream = include_directories('include')
 
 files_lib_host_iostream = files(
 )
+if host_machine.system() == 'darwin'
+  # macOS ar requires at least one member per static archive.
+  files_lib_host_iostream += files('iostream_stub.cpp')
+endif
 
 lib_host_iostream = static_library(
   'host_iostream',

--- a/host/meson.build
+++ b/host/meson.build
@@ -94,6 +94,13 @@ if use_gles or use_vulkan
   ]
 endif
 
+# GL include paths are needed even in Vulkan-only builds: the Vulkan server
+# includes the GLES dispatch headers (e.g. for interop declarations), so keep
+# them visible regardless of which decoders are enabled.
+inc_gl_server = include_directories('gl')
+inc_gl_snapshot = include_directories('gl/glsnapshot')
+inc_gl_openglesdispatch = include_directories('gl/OpenGLESDispatch/include')
+
 if use_gles
   subdir('gl')
 

--- a/host/native_sub_window.h
+++ b/host/native_sub_window.h
@@ -21,7 +21,7 @@
 #if GFXSTREAM_ENABLE_HOST_GLES
 #include <EGL/egl.h>
 #else
-#include "GlesCompat.h"
+#include "gles_compat.h"
 #endif
 
 #ifdef __cplusplus

--- a/host/snapshot/meson.build
+++ b/host/snapshot/meson.build
@@ -4,6 +4,10 @@
 inc_host_snapshot = include_directories('include')
 
 files_lib_host_snapshot = files()
+if host_machine.system() == 'darwin'
+  # macOS ar requires at least one member per static archive.
+  files_lib_host_snapshot += files('snapshot_stub.cpp')
+endif
 
 lib_host_snapshot = static_library(
   'host_snapshot',

--- a/host/snapshot/snapshot_stub.cpp
+++ b/host/snapshot/snapshot_stub.cpp
@@ -1,0 +1,2 @@
+// Intentionally empty: macOS ar(1) refuses to create an archive with no
+// members, so Darwin builds need at least one translation unit here.

--- a/host/virtio_gpu_gfxstream_renderer.cpp
+++ b/host/virtio_gpu_gfxstream_renderer.cpp
@@ -450,8 +450,7 @@ VG_EXPORT int stream_renderer_create_blob(uint32_t ctx_id, uint32_t res_handle,
     GFXSTREAM_TRACE_EVENT(GFXSTREAM_TRACE_STREAM_RENDERER_CATEGORY,
                           "stream_renderer_create_blob()");
 
-    sFrontend()->createBlob(ctx_id, res_handle, create_blob, handle);
-    return 0;
+    return sFrontend()->createBlob(ctx_id, res_handle, create_blob, handle);
 }
 
 VG_EXPORT int stream_renderer_export_blob(uint32_t res_handle,

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 # Copyright 2023 Android Open Source Project
 # SPDX-License-Identifier: Apache-2.0
 
-project('gfxstream', 'cpp', 'c',
+project('gfxstream', 'cpp', 'c', 'objc', 'objcpp',
          version : '0.1.2',
          license : 'Apache-2.0',
          default_options : ['cpp_std=gnu++17',


### PR DESCRIPTION
## Summary
- Normalize `shm_open()` names to be POSIX-compliant (leading `/`) on all platforms, and use `shm_open()` on macOS where there's no `memfd_create()`.
- Propagate the return value of `stream_renderer_create_blob()` instead of always returning success.
- Fix the macOS meson host build, which currently doesn't compile on main in any decoder configuration:
  - `project()` was missing the `objc`/`objcpp` languages, so meson can't even configure with `mac_native.m` / `native_sub_window_cocoa.mm` in the tree.
  - `gles_compat.h` typedefs `EGLNativeWindowType` as `unsigned int`, which truncates pointers on 64-bit. `native_sub_window_cocoa.mm` returns an `NSView*` through it.
  - `host/iostream` and `host/snapshot` are static libraries with no sources, which BSD `ar` refuses to archive.
  - `frame_buffer.h` / `native_sub_window.h` still include `"GlesCompat.h"` from before the rename to `gles_compat.h`.
- Add a macOS meson build job to `presubmit.yaml` (per review) so these paths stay compiled.

## Why
gfxstream works as the virtio-gpu backend on Apple Silicon hosts (MoltenVK on Metal, HVF VMMs like libkrun), but no CI compiles the macOS paths, so they rot. This gets the default host build green on macOS and keeps it that way.

## Validation
- Built locally on an Apple Silicon host with the exact commands the new job runs: `meson setup -Ddefault_library=static -Dgfxstream-build=host` + `meson compile`, deps from Homebrew (meson, ninja, molten-vk, vulkan-loader).
- The SHM and createBlob paths are exercised daily running Android in a libkrun VM on macOS.

Note: `-Ddecoders=vulkan` (Vulkan-only) now configures but still doesn't fully compile; that's coming in a follow-up PR.