### PR TITLE
gfxstream: Use O_RDONLY instead of O_RDWR for /dev/udmabuf

### DIFF
--- a/common/base/UdmabufCreator_linux.cpp
+++ b/common/base/UdmabufCreator_linux.cpp
@@ -81,7 +81,7 @@ UdmabufCreator::UdmabufCreator() {}
 UdmabufCreator::~UdmabufCreator() {}
 
 bool UdmabufCreator::init() {
-    auto rawDescriptor = open("/dev/udmabuf", O_RDWR);
+    auto rawDescriptor = open("/dev/udmabuf", O_RDONLY);
     if (rawDescriptor < 0) {
         return false;
     }


### PR DESCRIPTION
Opening the control interface /dev/udmabuf in O_RDONLY is sufficient to execute the UDMABUF_CREATE ioctl. This change restricts device access to read-only mode, resolving failures introduced by tightened SELinux constraints in ag/40547851.

Test: Tested udmabuf + gfxstream combination on a physical device.
Bug: 527245558
TAG=agy
CONV=2aa5001b-d852-48d2-a57f-0c2b769850f3