### PR TITLE
vulkan: Move instead of copy the resized scaled-readback buffer

### DIFF
--- a/host/vulkan/vk_common_operations.cpp
+++ b/host/vulkan/vk_common_operations.cpp
@@ -3698,7 +3698,7 @@ bool VkEmulation::readColorBufferPixelsScaledCpu(uint32_t colorBufferHandle, int
                 return false;
             }
 
-            readback_r8g8b8a8 = resized_readback_r8g8b8a8;
+            readback_r8g8b8a8 = std::move(resized_readback_r8g8b8a8);
             readbackWidth = readbackTargetWidth;
             readbackHeight = readbackTargetHeight;
         }


### PR DESCRIPTION
After ResizeRGBAImage() fills resized_readback_r8g8b8a8, the result was assigned back to readback_r8g8b8a8 by copy even though the temporary is a block-local that is destroyed immediately afterwards. Move it instead to avoid an extra copy of the full pixel buffer on every scaled/rotated CPU readback.

Test: bazel build //host/vulkan:gfxstream_vulkan_server