### PR TITLE
Add buffer transfer bounds validation tests

### DIFF
--- a/.github/workflows/presubmit_bazel.yml
+++ b/.github/workflows/presubmit_bazel.yml
@@ -71,5 +71,6 @@ jobs:
           host:gfxstream_framebuffer_tests \
           host/vulkan:gfxstream_compositorvk_tests \
           host/vulkan:gfxstream_emulatedphysicalmemory_tests \
+          host/vulkan:vk_common_operations_tests \
           tests/end2end:gfxstream_end2end_tests \
           ${{ inputs.additional-bazel-args }}

--- a/host/vulkan/BUILD.bazel
+++ b/host/vulkan/BUILD.bazel
@@ -245,6 +245,23 @@ cc_test(
 )
 
 cc_test(
+    name = "vk_common_operations_tests",
+    srcs = [
+        "vk_common_operations_tests.cpp",
+    ],
+    copts = GFXSTREAM_HOST_COPTS,
+    deps = [
+        ":gfxstream_vulkan_server",
+        "//common/base:gfxstream_common_base",
+        "//common/testenv:graphics_test_environment_support",
+        "//host:gfxstream_backend_static",
+        "//host/features:gfxstream_host_features",
+        "@com_google_googletest//:gtest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "gfxstream_emulatedphysicalmemory_tests",
     srcs = [
         "vk_emulated_physical_device_memory_tests.cpp",

--- a/host/vulkan/vk_common_operations_tests.cpp
+++ b/host/vulkan/vk_common_operations_tests.cpp
@@ -1,0 +1,105 @@
+// Copyright 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "vulkan/vk_common_operations.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "gfxstream/common/testing/graphics_test_environment.h"
+#include "gfxstream/host/features.h"
+#include "vulkan/vulkan_dispatch.h"
+
+namespace gfxstream {
+namespace host {
+namespace vk {
+namespace {
+
+// Brings up a real VkEmulation against the bundled software Vulkan driver and exercises the
+// guest-controlled offset/size validation in readBufferToBytes()/updateBufferFromBytes(). The
+// guest controls the offset and size of buffer transfers, so an out-of-range request must be
+// rejected rather than reading or writing past the buffer.
+class VkEmulationBufferTransferTest : public ::testing::Test {
+   protected:
+    static void SetUpTestSuite() {
+        ASSERT_TRUE(gfxstream::testing::SetupGraphicsTestEnvironment())
+            << "Failed to configure graphics test environment";
+    }
+
+    void SetUp() override {
+        VulkanDispatch* vk =
+            vkDispatch(!gfxstream::testing::IsGraphicsTestEnvironmentProvidingVulkanDriver());
+        ASSERT_NE(vk, nullptr);
+
+        gfxstream::host::FeatureSet features;
+        // Needed so that host-visible coherent memory is available for the staging buffer.
+        features.GlDirectMem.setEnabled(true);
+
+        mVkEmu = VkEmulation::create(vk, {}, features);
+        ASSERT_NE(mVkEmu, nullptr);
+    }
+
+    void TearDown() override { mVkEmu.reset(); }
+
+    std::unique_ptr<VkEmulation> mVkEmu;
+};
+
+TEST_F(VkEmulationBufferTransferTest, RejectsOutOfRangeTransfers) {
+    constexpr uint64_t kBufferSize = 4096;
+    constexpr uint32_t kBufferHandle = 1;
+    ASSERT_TRUE(mVkEmu->setupVkBuffer(kBufferSize, kBufferHandle, /*vulkanOnly=*/true));
+
+    std::vector<uint8_t> scratch(kBufferSize, 0xab);
+
+    // Offset entirely past the end of the buffer.
+    EXPECT_FALSE(mVkEmu->readBufferToBytes(kBufferHandle, kBufferSize + 1, 1, scratch.data()));
+    EXPECT_FALSE(mVkEmu->updateBufferFromBytes(kBufferHandle, kBufferSize + 1, 1, scratch.data()));
+
+    // Offset exactly at the end, with a non-zero size.
+    EXPECT_FALSE(mVkEmu->readBufferToBytes(kBufferHandle, kBufferSize, 1, scratch.data()));
+
+    // In-bounds offset, but size runs off the end.
+    EXPECT_FALSE(mVkEmu->readBufferToBytes(kBufferHandle, 1, kBufferSize, scratch.data()));
+    EXPECT_FALSE(mVkEmu->updateBufferFromBytes(kBufferHandle, 0, kBufferSize + 1, scratch.data()));
+
+    // offset + size would overflow if added naively; the subtraction-based check must still reject.
+    EXPECT_FALSE(mVkEmu->readBufferToBytes(kBufferHandle, kBufferSize,
+                                           ~static_cast<uint64_t>(0), scratch.data()));
+
+    mVkEmu->teardownVkBuffer(kBufferHandle);
+}
+
+TEST_F(VkEmulationBufferTransferTest, AllowsInRangeTransfers) {
+    constexpr uint64_t kBufferSize = 4096;
+    constexpr uint32_t kBufferHandle = 2;
+    ASSERT_TRUE(mVkEmu->setupVkBuffer(kBufferSize, kBufferHandle, /*vulkanOnly=*/true));
+
+    std::vector<uint8_t> scratch(kBufferSize, 0xcd);
+
+    // Whole-buffer and sub-range transfers within bounds must be accepted.
+    EXPECT_TRUE(mVkEmu->updateBufferFromBytes(kBufferHandle, 0, kBufferSize, scratch.data()));
+    EXPECT_TRUE(mVkEmu->readBufferToBytes(kBufferHandle, 0, kBufferSize, scratch.data()));
+    EXPECT_TRUE(mVkEmu->readBufferToBytes(kBufferHandle, kBufferSize / 2, kBufferSize / 2,
+                                          scratch.data()));
+
+    mVkEmu->teardownVkBuffer(kBufferHandle);
+}
+
+}  // namespace
+}  // namespace vk
+}  // namespace host
+}  // namespace gfxstream


### PR DESCRIPTION
Bring up a real VkEmulation against the bundled Vulkan driver and verify
that readBufferToBytes()/updateBufferFromBytes() reject guest-controlled
offset/size pairs that fall outside the buffer (offset past the end,
offset at the end, size running off the end, and an offset+size pair that
would overflow if added naively), while still accepting in-range whole
and partial transfers. This exercises the validation added in the buffer
read/update hardening change.
    
Test: bazel test //host/vulkan:gfxstream_emulation_buffer_transfer_tests
