### PR TITLE
Skip postsubmit cache population in forks

### DIFF
--- a/.github/workflows/postsubmit.yaml
+++ b/.github/workflows/postsubmit.yaml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   postsubmit-populate-bazel-cache:
+    # Only run in the upstream repository; skip in forks.
+    if: github.repository == 'google/gfxstream'
     runs-on: ubuntu-22.04
     steps:
     - name: Free disk space
@@ -40,6 +42,8 @@ jobs:
           --graphics_drivers=gles_angle_vulkan_swiftshader \
           --verbose_failures
   postsubmit-populate-bazel-cache-arm:
+    # Only run in the upstream repository; skip in forks.
+    if: github.repository == 'google/gfxstream'
     runs-on: ubuntu-22.04-arm
     steps:
     - name: Free disk space


### PR DESCRIPTION
The postsubmit workflow populates the upstream Bazel cache on every push to main and on a 3-hourly schedule. Forks have no use for this and it only consumes Actions minutes, so guard both jobs to run only in the upstream google/gfxstream repository. In a fork github.repository is the fork's slug, so the jobs are skipped.

Test: Presubmit (CI configuration only)