### PR TITLE
vulkan: Validate image content size on snapshot load

### DIFF
--- a/host/vulkan/vk_decoder_snapshot_utils.cpp
+++ b/host/vulkan/vk_decoder_snapshot_utils.cpp
@@ -337,12 +337,16 @@ void loadImageContent(gfxstream::Stream* stream, StateBlock* stateBlock, VkImage
             }
 
             VkExtent3D mipmapExtent = getMipmapExtent(imageCreateInfo.extent, mipLevel);
-            size_t bytes = stream->getBe64();
-            stream->read(mapped, bytes);
-
             if (!getFormatTransferInfo(imageCreateInfo.format, mipmapExtent, &transferInfo)) {
                 GFXSTREAM_FATAL("Failed to get transfer info for snapshot load");
             }
+
+            // Require the serialized size to match the expected per-mip transfer size.
+            size_t bytes = stream->getBe64();
+            if (bytes != transferInfo.stagingBufferCopySize) {
+                GFXSTREAM_FATAL("Unexpected image content size on snapshot load");
+            }
+            stream->read(mapped, bytes);
             std::vector<VkBufferImageCopy>& bufferImageCopies = transferInfo.bufferImageCopies;
             VkImageAspectFlags aspects = 0;
             for (const auto& copy : bufferImageCopies) {


### PR DESCRIPTION
loadImageContent() read a per-mip byte count straight from the stream and copied that many bytes into the mapped staging buffer with no check, unlike loadBufferContent() which validates the size. A malformed snapshot could overflow the staging allocation.

Compute the expected transfer size first and require the serialized count to match it before reading.

Test: bazel build //host/vulkan:gfxstream_vulkan_server