### PR TITLE
vulkan: Map R4G4B4A4_UNORM to VK_FORMAT_R4G4B4A4_UNORM_PACK16

### DIFF
--- a/host/vulkan/vk_format_utils.cpp
+++ b/host/vulkan/vk_format_utils.cpp
@@ -336,6 +336,8 @@ std::optional<VkFormat> ToVkFormat(GfxstreamFormat format) {
             return VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16;
         case GfxstreamFormat::R10G10B10A2_UNORM:
             return VK_FORMAT_A2B10G10R10_UNORM_PACK32;
+        case GfxstreamFormat::R4G4B4A4_UNORM:
+            return VK_FORMAT_R4G4B4A4_UNORM_PACK16;
         case GfxstreamFormat::R16_UNORM:
             return VK_FORMAT_R16_UNORM;
         case GfxstreamFormat::R16G16B16_FLOAT:
@@ -375,6 +377,8 @@ std::optional<GfxstreamFormat> ToGfxstreamFormat(VkFormat format) {
     switch (format) {
         case VK_FORMAT_B4G4R4A4_UNORM_PACK16:
             return GfxstreamFormat::B4G4R4A4_UNORM;
+        case VK_FORMAT_R4G4B4A4_UNORM_PACK16:
+            return GfxstreamFormat::R4G4B4A4_UNORM;
         case VK_FORMAT_B5G5R5A1_UNORM_PACK16:
             return GfxstreamFormat::B5G5R5A1_UNORM;
         case VK_FORMAT_B8G8R8A8_UNORM:


### PR DESCRIPTION
ToVkFormat had no mapping for GfxstreamFormat::R4G4B4A4_UNORM, so creating an RGBA4 color buffer failed with "Unsupported internal format" on every driver except under the lavapipe ICD override, where the format is substituted with B4G4R4A4 before the lookup. The format is already listed in the image support queries and the linear format plane layouts; only the enum mapping (and its inverse) was missing.

With the mapping in place, RoundTripsRgba4ColorBufferContents exercises the native RGBA4 path instead of skipping.

Test: bazel test //host/vulkan:vk_common_operations_tests
Change-Id: I4b4e9fb042b8aa62cef851c8cb5a5eb270c91b9a