### PR TITLE
vulkan: Treat zero-size buffer transfers as no-ops

### DIFF
--- a/host/vulkan/vk_common_operations.cpp
+++ b/host/vulkan/vk_common_operations.cpp
@@ -4663,6 +4663,12 @@ bool VkEmulation::readBufferToBytes(uint32_t bufferHandle, uint64_t offset, uint
         return false;
     }
 
+    // Nothing to transfer. Recording a zero-size copy is not allowed
+    // (VUID-VkBufferCopy-size-01988).
+    if (size == 0) {
+        return true;
+    }
+
     const auto& stagingBufferInfo = mStaging;
     if (size > stagingBufferInfo.mAllocationSize) {
         GFXSTREAM_ERROR("Failed to read from Buffer:%d, staging buffer too small.", bufferHandle);
@@ -4754,6 +4760,12 @@ bool VkEmulation::updateBufferFromBytes(uint32_t bufferHandle, uint64_t offset, 
                         "] out of range of buffer size %" PRIu64 ".",
                         bufferHandle, offset, size, bufferInfo->size);
         return false;
+    }
+
+    // Nothing to transfer. Recording a zero-size copy is not allowed
+    // (VUID-VkBufferCopy-size-01988).
+    if (size == 0) {
+        return true;
     }
 
     const auto& stagingBufferInfo = mStaging;

--- a/host/vulkan/vk_common_operations_tests.cpp
+++ b/host/vulkan/vk_common_operations_tests.cpp
@@ -108,6 +108,27 @@ TEST_F(VkEmulationBufferTransferTest, AllowsInRangeTransfers) {
     mVkEmu->teardownVkBuffer(kBufferHandle);
 }
 
+TEST_F(VkEmulationBufferTransferTest, TreatsZeroSizeTransfersAsNoOp) {
+    constexpr uint64_t kBufferSize = 4096;
+    constexpr uint32_t kBufferHandle = 8;
+    ASSERT_TRUE(mVkEmu->setupVkBuffer(kBufferSize, kBufferHandle, /*vulkanOnly=*/true));
+
+    // Zero-size transfers at any in-range offset (including one-past-the-end) succeed as
+    // no-ops. They must not reach the device: Vulkan forbids recording zero-size copies
+    // (VUID-VkBufferCopy-size-01988).
+    uint8_t byte = 0;
+    EXPECT_TRUE(mVkEmu->readBufferToBytes(kBufferHandle, 0, 0, &byte));
+    EXPECT_TRUE(mVkEmu->updateBufferFromBytes(kBufferHandle, 0, 0, &byte));
+    EXPECT_TRUE(mVkEmu->readBufferToBytes(kBufferHandle, kBufferSize, 0, &byte));
+    EXPECT_TRUE(mVkEmu->updateBufferFromBytes(kBufferHandle, kBufferSize, 0, &byte));
+
+    // A zero-size transfer with an out-of-range offset is still rejected.
+    EXPECT_FALSE(mVkEmu->readBufferToBytes(kBufferHandle, kBufferSize + 1, 0, &byte));
+    EXPECT_FALSE(mVkEmu->updateBufferFromBytes(kBufferHandle, kBufferSize + 1, 0, &byte));
+
+    mVkEmu->teardownVkBuffer(kBufferHandle);
+}
+
 TEST_F(VkEmulationBufferTransferTest, RejectsUndersizedDepthStencilColorBufferTransfers) {
     constexpr uint32_t kWidth = 8;
     constexpr uint32_t kHeight = 8;


### PR DESCRIPTION
A guest-controlled transfer with an in-range offset and size 0 passed the bounds check and recorded a VkBufferCopy with size 0, which the Vulkan spec forbids (VUID-VkBufferCopy-size-01988). Return success without touching the device instead, in both readBufferToBytes and updateBufferFromBytes. Zero-size transfers with an out-of-range offset are still rejected.

Test: bazel test //host/vulkan:vk_common_operations_tests
Change-Id: I641878b897b41c7476d14e66380bf86d6908e9f4