### PR TITLE
gfxstream: delete lib_host_snapshot in meson.build 

### DIFF
--- a/host/gl/gles1_dec/meson.build
+++ b/host/gl/gles1_dec/meson.build
@@ -25,7 +25,6 @@ lib_gles1_dec = static_library(
   link_with: [
     lib_common_base,
     lib_gl_openglesdispatch,
-    lib_host_iostream,
     lib_host_library,
     lib_common_logging,
   ],

--- a/host/gl/gles2_dec/meson.build
+++ b/host/gl/gles2_dec/meson.build
@@ -28,7 +28,6 @@ lib_gles2_dec = static_library(
     lib_common_base,
     lib_gl_snapshot,
     lib_host_common,
-    lib_host_iostream,
     lib_common_logging,
   ],
 )

--- a/host/gl/glestranslator/common/meson.build
+++ b/host/gl/glestranslator/common/meson.build
@@ -50,6 +50,5 @@ lib_gl_common = static_library(
     lib_host_common,
     lib_host_library,
     lib_common_logging,
-    lib_host_snapshot,
   ],
 )

--- a/host/gl/glestranslator/egl/meson.build
+++ b/host/gl/glestranslator/egl/meson.build
@@ -76,6 +76,5 @@ lib_egl_translator = static_library(
     lib_host_common,
     lib_host_library,
     lib_common_logging,
-    lib_host_snapshot,
   ],
 )

--- a/host/gl/glestranslator/gles_cm/meson.build
+++ b/host/gl/glestranslator/gles_cm/meson.build
@@ -30,6 +30,5 @@ lib_glescm_translator = static_library(
     lib_common_base,
     lib_host_common,
     lib_common_logging,
-    lib_host_snapshot,
   ],
 )

--- a/host/gl/glestranslator/gles_v2/meson.build
+++ b/host/gl/glestranslator/gles_v2/meson.build
@@ -36,6 +36,5 @@ lib_glesv2_translator = static_library(
     lib_host_common,
     lib_host_decoder_common,
     lib_common_logging,
-    lib_host_snapshot,
   ],
 )

--- a/host/gl/meson.build
+++ b/host/gl/meson.build
@@ -79,7 +79,6 @@ lib_gl_server = static_library(
     lib_host_common,
     lib_host_decoder_common,
     lib_host_features,
-    lib_host_iostream,
     lib_host_library,
   ],
 )

--- a/host/gl/meson.build
+++ b/host/gl/meson.build
@@ -81,6 +81,5 @@ lib_gl_server = static_library(
     lib_host_features,
     lib_host_iostream,
     lib_host_library,
-    lib_host_snapshot,
   ],
 )

--- a/host/iostream/meson.build
+++ b/host/iostream/meson.build
@@ -2,12 +2,3 @@
 # SPDX-License-Identifier: Apache-2.0
 
 inc_host_iostream = include_directories('include')
-
-files_lib_host_iostream = files(
-)
-
-lib_host_iostream = static_library(
-  'host_iostream',
-  files_lib_host_iostream,
-  include_directories: [inc_host_iostream],
-)

--- a/host/meson.build
+++ b/host/meson.build
@@ -52,7 +52,6 @@ link_gfxstream_backend = [
   lib_host_iostream,
   lib_host_library,
   lib_common_logging,
-  lib_host_snapshot,
   lib_host_tracing,
 ]
 

--- a/host/meson.build
+++ b/host/meson.build
@@ -49,7 +49,6 @@ link_gfxstream_backend = [
   lib_host_address_space,
   lib_host_common,
   lib_host_features,
-  lib_host_iostream,
   lib_host_library,
   lib_common_logging,
   lib_host_tracing,

--- a/host/renderControl_dec/meson.build
+++ b/host/renderControl_dec/meson.build
@@ -21,7 +21,6 @@ lib_composer = static_library(
   ],
   link_with: [
     lib_common_base,
-    lib_host_iostream,
     lib_common_logging,
   ],
 )

--- a/host/snapshot/meson.build
+++ b/host/snapshot/meson.build
@@ -2,11 +2,3 @@
 # SPDX-License-Identifier: Apache-2.0
 
 inc_host_snapshot = include_directories('include')
-
-files_lib_host_snapshot = files()
-
-lib_host_snapshot = static_library(
-  'host_snapshot',
-  files_lib_host_snapshot,
-  include_directories: [inc_host_snapshot],
-)

--- a/host/vulkan/meson.build
+++ b/host/vulkan/meson.build
@@ -104,7 +104,6 @@ lib_vulkan_server = static_library(
     lib_host_common,
     lib_host_compressed_textures,
     lib_host_features,
-    lib_host_iostream,
     lib_host_library,
     lib_host_tracing,
     lib_vulkan_cereal,

--- a/host/vulkan/meson.build
+++ b/host/vulkan/meson.build
@@ -106,7 +106,6 @@ lib_vulkan_server = static_library(
     lib_host_features,
     lib_host_iostream,
     lib_host_library,
-    lib_host_snapshot,
     lib_host_tracing,
     lib_vulkan_cereal,
   ],


### PR DESCRIPTION
Seems to work without empty lib_host_snapshot or lib_host_iostream.