### PR TITLE
gfxstream: update VIRGL_FORMAT_P210 to 481

### DIFF
--- a/host/virtio_gpu_format_utils.h
+++ b/host/virtio_gpu_format_utils.h
@@ -48,7 +48,7 @@ namespace host {
 #define VIRGL_FORMAT_YV12                    163
 #define VIRGL_FORMAT_NV12                    166
 #define VIRGL_FORMAT_P010                    314
-#define VIRGL_FORMAT_P210                    317
+#define VIRGL_FORMAT_P210                    481
 // clang-format on
 
 inline std::optional<GfxstreamFormat> ToGfxstreamFormat(uint32_t virglFormat) {


### PR DESCRIPTION
Update VIRGL_FORMAT_P210 from 317 to 481 to align with upstream virglrenderer / Mesa format definitions and minigbm.

Test: MctsMediaV2TestCases:CodecDecoderSurfaceTest
Bug: 525088727