### PR TITLE
gfxstream: free an external handle by its own type

### DIFF
--- a/host/vulkan/vk_common_operations.cpp
+++ b/host/vulkan/vk_common_operations.cpp
@@ -2622,7 +2622,18 @@ void VkEmulation::freeExternalMemoryLocked(VulkanDispatch* vk,
 #ifdef _WIN32
         CloseHandle(static_cast<HANDLE>(reinterpret_cast<void*>(info->handleInfo->handle)));
 #elif defined(__ANDROID__)
-        AHardwareBuffer_release(static_cast<AHardwareBuffer*>(reinterpret_cast<void*>(info->handleInfo->handle)));
+        // An Android host is not necessarily in AndroidAHB mode, so the handle has to be released
+        // according to its own type rather than the platform's default one.
+        switch (info->handleInfo->streamHandleType) {
+            case STREAM_HANDLE_TYPE_MEM_OPAQUE_FD:
+            case STREAM_HANDLE_TYPE_MEM_DMABUF:
+                close(static_cast<int>(info->handleInfo->handle));
+                break;
+            default:
+                AHardwareBuffer_release(
+                    static_cast<AHardwareBuffer*>(reinterpret_cast<void*>(info->handleInfo->handle)));
+                break;
+        }
 #else
         switch (info->handleInfo->streamHandleType) {
             case STREAM_HANDLE_TYPE_MEM_OPAQUE_FD:


### PR DESCRIPTION
`freeExternalMemoryLocked()` releases the handle as an `AHardwareBuffer` on any
Android host without consulting `streamHandleType`. That is only correct while
the host is in `AndroidAHB` mode — `VulkanExternalMemoryMode` can select
`OpaqueFd`, in which case the handle is an fd and the release reinterprets a
small integer as a pointer:

```
signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x137
#00 android::RefBase::decStrong(void const*) const+10
#01 VkEmulation::freeExternalMemoryLocked(...)+440
#02 VkEmulation::teardownVkColorBufferLocked(unsigned int)+492
#03 VkEmulation::initFeatures(VkEmulation::Features)+2577
```

`rdi` held `0x12f`, i.e. fd 303, on the first ColorBuffer teardown during
`initFeatures()`.

This dispatches on `streamHandleType` instead, matching what the non-Android
branch directly below already does, and keeps `AHardwareBuffer_release` for the
AHB case. Unknown handle types keep the previous behaviour, so there is **no
change for a host in `AndroidAHB` mode**.

Found while investigating Weston's GL renderer on Intel PTL; @gurchetansingh
suggested posting it here.

Tested on an Intel PTL Android host: the Linux VM boots and composites
unchanged in the default `AndroidAHB` mode, and with
`VulkanExternalMemoryMode:OpaqueFd` the SIGSEGV above no longer occurs.
