### PR TITLE
gfxstream: support linear ColorBuffer allocation for scanout

### DIFF
--- a/host/color_buffer.cpp
+++ b/host/color_buffer.cpp
@@ -47,7 +47,8 @@ class ColorBuffer::Impl : public LazySnapshotObj<ColorBuffer::Impl> {
    public:
     static std::unique_ptr<Impl> create(gl::EmulationGl* emulationGl, vk::VkEmulation* emulationVk,
                                         uint32_t width, uint32_t height, GfxstreamFormat format,
-                                        HandleType handle, gfxstream::Stream* stream = nullptr);
+                                        HandleType handle, gfxstream::Stream* stream = nullptr,
+                                        bool linear = false);
 
     static std::unique_ptr<Impl> onLoad(gl::EmulationGl* emulationGl, vk::VkEmulation* emulationVk,
                                         gfxstream::Stream* stream);
@@ -119,7 +120,7 @@ ColorBuffer::Impl::Impl(HandleType handle, uint32_t width, uint32_t height, Gfxs
 /*static*/
 std::unique_ptr<ColorBuffer::Impl> ColorBuffer::Impl::create(
     gl::EmulationGl* emulationGl, vk::VkEmulation* emulationVk, uint32_t width, uint32_t height,
-    GfxstreamFormat format, HandleType handle, gfxstream::Stream* stream) {
+    GfxstreamFormat format, HandleType handle, gfxstream::Stream* stream, bool linear) {
     std::unique_ptr<Impl> colorBuffer(new Impl(handle, width, height, format));
 
     if (stream) {
@@ -148,7 +149,8 @@ std::unique_ptr<ColorBuffer::Impl> ColorBuffer::Impl::create(
 #else
         const bool vulkanOnly = true;
 #endif
-        const uint32_t memoryProperty = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+        const uint32_t memoryProperty = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT |
+            (linear ? VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT : 0);
         const uint32_t mipLevels = 1;
         colorBuffer->mColorBufferVk = vk::ColorBufferVk::create(
             *emulationVk, handle, width, height, format, vulkanOnly, memoryProperty, mipLevels);
@@ -467,11 +469,12 @@ std::optional<BlobDescriptorInfo> ColorBuffer::Impl::exportBlob() {
 std::shared_ptr<ColorBuffer> ColorBuffer::create(gl::EmulationGl* emulationGl,
                                                  vk::VkEmulation* emulationVk, uint32_t width,
                                                  uint32_t height, GfxstreamFormat format,
-                                                 HandleType handle, gfxstream::Stream* stream) {
+                                                 HandleType handle, gfxstream::Stream* stream,
+                                                 bool linear) {
     std::shared_ptr<ColorBuffer> colorbuffer(new ColorBuffer());
 
-    colorbuffer->mImpl =
-        ColorBuffer::Impl::create(emulationGl, emulationVk, width, height, format, handle, stream);
+    colorbuffer->mImpl = ColorBuffer::Impl::create(emulationGl, emulationVk, width, height, format,
+                                                   handle, stream, linear);
     if (!colorbuffer->mImpl) {
         return nullptr;
     }

--- a/host/color_buffer.h
+++ b/host/color_buffer.h
@@ -50,9 +50,13 @@ namespace host {
 class ColorBuffer : public IColorBuffer, public LazySnapshotObj<ColorBuffer> {
    public:
     static std::shared_ptr<ColorBuffer> create(gl::EmulationGl* emulationGl,
-                                               vk::VkEmulation* emulationVk, uint32_t width,
-                                               uint32_t height, GfxstreamFormat format,
-                                               HandleType handle, Stream* stream = nullptr);
+                                               vk::VkEmulation* emulationVk,
+                                               uint32_t width,
+                                               uint32_t height,
+                                               GfxstreamFormat format,
+                                               HandleType handle,
+                                               Stream* stream = nullptr,
+                                               bool linear = false);
 
     static std::shared_ptr<ColorBuffer> onLoad(gl::EmulationGl* emulationGl,
                                                vk::VkEmulation* emulationVk, Stream* stream);

--- a/host/frame_buffer.cpp
+++ b/host/frame_buffer.cpp
@@ -367,7 +367,8 @@ class FrameBuffer::Impl : public gfxstream::base::EventNotificationSupport<Frame
                                            GLenum internalFormat,
                                            FrameworkFormat frameworkFormat);
     bool createColorBufferWithResourceHandle(int p_width, int p_height,
-                                             GfxstreamFormat format, HandleType handle);
+                                             GfxstreamFormat format, HandleType handle,
+                                             bool linear = false);
     bool createColorBufferWithResourceHandleDeprecated(int width, int height,
                                                        GLenum internalFormat,
                                                        FrameworkFormat frameworkFormat,
@@ -813,7 +814,8 @@ class FrameBuffer::Impl : public gfxstream::base::EventNotificationSupport<Frame
         m_framebuffer->fireEvent({FrameBufferChange::FrameReady, mFrameNumber++});
     }
     bool createColorBufferWithResourceHandleLocked(int p_width, int p_height,
-                                                   GfxstreamFormat format, HandleType handle);
+                                                   GfxstreamFormat format, HandleType handle,
+                                                   bool linear = false);
     bool createBufferWithResourceHandleLocked(uint64_t p_size, HandleType handle,
                                               uint32_t memoryProperty);
 
@@ -2031,7 +2033,8 @@ HandleType FrameBuffer::Impl::createColorBufferDeprecated(int width, int height,
 
 bool FrameBuffer::Impl::createColorBufferWithResourceHandle(int p_width, int p_height,
                                                             GfxstreamFormat format,
-                                                            HandleType handle) {
+                                                            HandleType handle,
+                                                            bool linear) {
     {
         AutoLock mutex(m_lock);
         sweepColorBuffersLocked();
@@ -2044,7 +2047,7 @@ bool FrameBuffer::Impl::createColorBufferWithResourceHandle(int p_width, int p_h
             return false;
         }
 
-        if (!createColorBufferWithResourceHandleLocked(p_width, p_height, format, handle)) {
+        if (!createColorBufferWithResourceHandleLocked(p_width, p_height, format, handle, linear)) {
             GFXSTREAM_ERROR("Could not create color buffer");
             return false;
         }
@@ -2068,9 +2071,10 @@ bool FrameBuffer::Impl::createColorBufferWithResourceHandleDeprecated(
 
 bool FrameBuffer::Impl::createColorBufferWithResourceHandleLocked(int p_width, int p_height,
                                                                   GfxstreamFormat format,
-                                                                  HandleType handle) {
+                                                                  HandleType handle,
+                                                                  bool linear) {
     ColorBufferPtr cb = ColorBuffer::create(m_emulationGl.get(), m_emulationVk.get(), p_width,
-                                            p_height, format, handle, nullptr /*stream*/);
+                                            p_height, format, handle, nullptr /*stream*/, linear);
     if (cb.get() == nullptr) {
         GFXSTREAM_ERROR("Failed to create ColorBuffer:%d format:%d with:%d height:%d", handle,
                         format, p_width, p_height);
@@ -4516,8 +4520,8 @@ HandleType FrameBuffer::createColorBufferDeprecated(int width, int height, GLenu
 }
 
 bool FrameBuffer::createColorBufferWithResourceHandle(int width, int height, GfxstreamFormat format,
-                                                      HandleType handle) {
-    return mImpl->createColorBufferWithResourceHandle(width, height, format, handle);
+                                                      HandleType handle, bool linear) {
+    return mImpl->createColorBufferWithResourceHandle(width, height, format, handle, linear);
 }
 
 bool FrameBuffer::createColorBufferWithResourceHandleDeprecated(int width, int height,

--- a/host/frame_buffer.h
+++ b/host/frame_buffer.h
@@ -154,7 +154,7 @@ class FrameBuffer : public gfxstream::base::EventNotificationSupport<FrameBuffer
     // virtio-gpu's RESOURCE_CREATE ioctl.
     // Returns true on success, false otherwise.
     bool createColorBufferWithResourceHandle(int p_width, int p_height, GfxstreamFormat format,
-                                             HandleType handle);
+                                             HandleType handle, bool linear = false);
 
     bool createColorBufferWithResourceHandleDeprecated(int width, int height, GLenum internalFormat,
                                                        FrameworkFormat frameworkFormat,

--- a/host/virtio_gpu_resource.cpp
+++ b/host/virtio_gpu_resource.cpp
@@ -175,9 +175,10 @@ std::optional<VirtioGpuResource> VirtioGpuResource::Create(
             return std::nullopt;
         }
         auto format = *formatOpt;
+        const bool linear = (args->bind & VIRGL_BIND_LINEAR) != 0;
 
         if (!FrameBuffer::getFB()->createColorBufferWithResourceHandle(args->width, args->height,
-                                                                       format, args->handle)) {
+                                                                       format, args->handle, linear)) {
             const std::string formatString = ToString(format);
             GFXSTREAM_ERROR("Failed to create color buffer with resource handle %d. (%dx%d, format: %s)",
                             args->handle, args->width, args->height, formatString.c_str());

--- a/host/vulkan/vk_android_native_buffer_operations.cpp
+++ b/host/vulkan/vk_android_native_buffer_operations.cpp
@@ -193,8 +193,9 @@ std::unique_ptr<AndroidNativeBufferInfo> AndroidNativeBufferInfo::create(
             return nullptr;
         }
 
-        // Update create flags to match the color buffer imported
+        // Update create flags and tiling to match the color buffer imported
         createImageCi.flags = importedColorBufferInfo.imageCreateInfoShallow.flags;
+        createImageCi.tiling = importedColorBufferInfo.imageCreateInfoShallow.tiling;
 
         const auto& importedColorBufferMemoryInfo = importedColorBufferInfo.memory;
 


### PR DESCRIPTION
When VIRGL_BIND_LINEAR is specified by the guest when creating a virtio-gpu resource, allocate the ColorBuffer with host visible memory property and linear tiling support. Also preserve the imported ColorBuffer's tiling when creating AndroidNativeBufferInfo.

Bug: 527240973
TAG=agy
CONV=afb1dcde-9a3d-455d-91b2-bcf6e118ffb8