### PR TITLE
gfxstream: export a ColorBuffer's memory regardless of ExternalBlob

### DIFF
--- a/host/virtio_gpu_resource.cpp
+++ b/host/virtio_gpu_resource.cpp
@@ -252,42 +252,42 @@ std::optional<VirtioGpuResource> VirtioGpuResource::Create(
             return std::nullopt;
         }
         resource.mBlobMemory.emplace(std::move(memory));
-    } else if (features.ExternalBlob.enabled()) {
-        if (createBlobArgs->blob_mem == STREAM_BLOB_MEM_GUEST &&
-            (createBlobArgs->blob_flags & STREAM_BLOB_FLAG_CREATE_GUEST_HANDLE)) {
+    } else if (features.ExternalBlob.enabled() &&
+               createBlobArgs->blob_mem == STREAM_BLOB_MEM_GUEST &&
+               (createBlobArgs->blob_flags & STREAM_BLOB_FLAG_CREATE_GUEST_HANDLE)) {
 #if defined(__ANDROID__)
-            ExternalObjectManager::get()->addBlobDescriptorInfo(
-                contextId, createBlobArgs->blob_id, handle->os_handle, handle->handle_type, 0,
-                std::nullopt);
+        ExternalObjectManager::get()->addBlobDescriptorInfo(
+            contextId, createBlobArgs->blob_id, handle->os_handle, handle->handle_type, 0,
+            std::nullopt);
 #elif defined(__linux__) || defined(__QNX__)
-            ManagedDescriptor managedHandle(handle->os_handle);
-            ExternalObjectManager::get()->addBlobDescriptorInfo(
-                contextId, createBlobArgs->blob_id, std::move(managedHandle), handle->handle_type,
-                0, std::nullopt);
+        ManagedDescriptor managedHandle(handle->os_handle);
+        ExternalObjectManager::get()->addBlobDescriptorInfo(
+            contextId, createBlobArgs->blob_id, std::move(managedHandle), handle->handle_type, 0,
+            std::nullopt);
 #else
-            GFXSTREAM_ERROR("Failed to create blob: unimplemented external blob.");
-            return std::nullopt;
+        GFXSTREAM_ERROR("Failed to create blob: unimplemented external blob.");
+        return std::nullopt;
 #endif
-        } else {
-            if (!descriptorInfoOpt) {
-                descriptorInfoOpt = ExternalObjectManager::get()->removeBlobDescriptorInfo(
-                    contextId, createBlobArgs->blob_id);
-            }
-            if (!descriptorInfoOpt) {
-                GFXSTREAM_ERROR("Failed to create blob: no external blob descriptor.");
-                return std::nullopt;
-            }
+    } else {
+        // ExternalBlob picks the map_blob transport (descriptor vs. host-visible mapping); it
+        // does not gate scanout, so a ColorBuffer's descriptor may be registered regardless of
+        // the feature. Probe for it before falling back to a mapping.
+        if (!descriptorInfoOpt) {
+            descriptorInfoOpt = ExternalObjectManager::get()->removeBlobDescriptorInfo(
+                contextId, createBlobArgs->blob_id);
+        }
+        if (descriptorInfoOpt) {
             resource.mBlobMemory.emplace(
                 std::make_shared<BlobDescriptorInfo>(std::move(*descriptorInfoOpt)));
+        } else {
+            auto memoryMappingOpt =
+                ExternalObjectManager::get()->removeMapping(contextId, createBlobArgs->blob_id);
+            if (!memoryMappingOpt) {
+                GFXSTREAM_ERROR("Failed to create blob: no external blob descriptor or mapping.");
+                return std::nullopt;
+            }
+            resource.mBlobMemory.emplace(std::move(*memoryMappingOpt));
         }
-    } else {
-        auto memoryMappingOpt =
-            ExternalObjectManager::get()->removeMapping(contextId, createBlobArgs->blob_id);
-        if (!memoryMappingOpt) {
-            GFXSTREAM_ERROR("Failed to create blob: no external blob mapping.");
-            return std::nullopt;
-        }
-        resource.mBlobMemory.emplace(std::move(*memoryMappingOpt));
     }
 
     return resource;

--- a/host/vulkan/vk_decoder_global_state.cpp
+++ b/host/vulkan/vk_decoder_global_state.cpp
@@ -7347,7 +7347,10 @@ class VkDecoderGlobalState::Impl {
             ExternalObjectManager::get()->addBlobDescriptorInfo(
                 virtioGpuContextId, hostBlobId, info->sharedMemory->releaseHandle(),
                 STREAM_HANDLE_TYPE_MEM_SHM, info->caching, std::nullopt);
-        } else if (m_vkEmulation->getFeatures().ExternalBlob.enabled()) {
+        } else if (m_vkEmulation->getFeatures().ExternalBlob.enabled() ||
+                   info->boundColorBuffer.has_value()) {
+            // A ColorBuffer's memory must always be exported for scanout, regardless of
+            // ExternalBlob (which only governs the map_blob transport for non-scanout memory).
 #ifdef __APPLE__
             if (m_vkEmulation->getExternalMemoryMode() == ExternalMemory::Mode::Metal) {
                 GFXSTREAM_FATAL("ExternalBlob feature is not supported with external memory metal");


### PR DESCRIPTION
Addresses the point @gurchetansingh raised on the ARSP review: `ExternalBlob` was
doing two unrelated jobs — picking the map_blob transport (descriptor vs. host-visible
mapping) for ordinary memory, and gating whether a ColorBuffer's memory gets exported
for scanout at all. Those need to be independent.

### The bug

With `ExternalBlob` off (we need it off so `SystemBlob` can carry host-visible memory —
`VulkanAllocateHostVisibleAsUdmabuf` fails on newer hosts, and plain `ExternalBlob`
exports as an AHardwareBuffer handle that crosvm's `resource_map_blob()` rejects),
`vkGetBlobInternal` never registered a ColorBuffer's descriptor, and
`VirtioGpuResource::Create`'s blob path only knew how to look up a *mapping*. The
scanout blob had neither, so every frame failed:

```
virtio_gpu_resource.cpp: Failed to create blob: no external blob mapping.
virtio_gpu_frontend.cpp: Failed to transfer: failed to find resource 6.
```

### Fix

- `vkGetBlobInternal`: export+register the descriptor whenever the memory backs a
  ColorBuffer (`info->boundColorBuffer`), independent of the flag.
- `VirtioGpuResource::Create`: probe for a registered descriptor first, then fall back
  to a mapping, instead of picking one or the other by the flag.

The `blob_id==0` ring path and the guest-handle sub-branch are untouched — those are
real transport choices, not scanout.

Tested on Intel PTL (fatcat) both with `ExternalBlob:disabled` (the case this fixes —
Weston reaches its GL renderer, desktop composites via AHB-FLIP, no blob/resource
errors) and with the shipping `SystemBlob:enabled;ExternalBlob:enabled` config (no
regression).