### PR TITLE
ci: Use stable Go version in presubmit for buildozer

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -28,7 +28,7 @@ jobs:
     - name: Install go
       uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
       with:
-        go-version: '1.23.1'
+        go-version: 'stable'
     - name: Install buildozer
       run: go install github.com/bazelbuild/buildtools/buildozer@latest
     - name: Validate formatting


### PR DESCRIPTION
github.com/bazelbuild/buildtools/buildozer@latest has transitive dependencies (golang.org/x/sys) that now require Go >= 1.25.0. Update actions/setup-go in the run-buildozer job to use 'stable' rather than the pinned 1.23.1 so that buildozer can be installed successfully.